### PR TITLE
Fixes unnecessary invalid syntax error

### DIFF
--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -159,6 +159,7 @@ function onCommand(cmd) {
 	if (cmd == "hstshijack.show") {
 		showModule()
 	}
+	return true
 }
 
 function onLoad() {


### PR DESCRIPTION
fix for [sys.log] [err] Unknown or invalid syntax "hstshijack.show", type help for the help menu. (ref. PR #17)