### PR TITLE
Update http-req-dump.js

### DIFF
--- a/http-req-dump.js
+++ b/http-req-dump.js
@@ -16,8 +16,20 @@ function Y(s) {
     return "\033[33m" + s + RESET;
 }
 
+function BLACK_BLUE(s) {
+    return "\033[104;30m" + s + RESET;
+}
+
+function BLACK_RED(s) {
+    return "\033[41;30m" + s + RESET;
+}
+
 function DIM(s) {
     return "\033[2m" + s + RESET;
+}
+
+function GREY(s) {
+    return "\033[30m" + s + RESET;
 }
 
 function BOLD(s) {
@@ -25,66 +37,109 @@ function BOLD(s) {
 }
 
 function dumpHeaders(req) {
-    log( "> " + BOLD(G("Headers")) );
-    headers = req.Headers.split("\r\n");
+    headers = req.Headers.replace(/\r\n$/g, "").split("\r\n");
+
+    msg = "\n  " + BOLD("Headers") + "\n\n";
+
     for (var i = 0; i < headers.length; i++) {
         header_name = headers[i].replace(/:.*/, "");
         header_value = headers[i].replace(/.*?: /, "");
-        log( "  " + B(header_name) + " : " + DIM(header_value) );
+
+        msg += "    " + G(header_name) + " => " + BOLD(header_value) + "\n";
     }
+
+    console.log(msg);
 }
 
 function dumpPlain(req) {
-    log( "  > " + BOLD(G("Text")) );
+    body = req.ReadBody();
 
-    var body = req.ReadBody();
-
-    log( "   " + Y(body) );
+    if (req.Body.length > 0) {
+        console.log("  " + BOLD("Text") + "\n\n    " + Y(body) + "\n");
+    }
 }
 
 function dumpForm(req) {
-    log( "  > " + BOLD(G("Form")) );
+    form = req.ParseForm();
 
-    var form = req.ParseForm();
-    for (var key in form) {
-        log( "   " + B(key) + " : " + Y(form[key]) );
+    if (Object.keys(form).length > 0) {
+        msg = "  " + BOLD("Form") + "\n\n";
+
+        for (var key in form) {
+            msg += "    " + B(strip(key)) + " : " + Y(strip(form[key])) + "\n";
+        }
+
+        console.log(msg);
     }
+}
+
+function dumpQuery(req) {
+    params = req.Query.split("&");
+
+    msg = "  " + BOLD("Query") + "\n\n";
+
+    for (var i = 0; i < params.length; i++) {
+        param_name = params[i].split("=")[0];
+        param_value = params[i].split("=")[1];
+
+        if (param_name != undefined && param_value != undefined && param_name.length > 0 && param_value.length > 0) {
+            try {
+                msg += "    " + B(strip(decodeURIComponent(param_name))) + " : " + Y(strip(decodeURIComponent(param_value))) + "\n";
+            } catch(err) {
+                msg += "    " + B(strip(param_name)) + " : " + Y(strip(param_value)) + "\n";
+                log_debug("could not decode URI parameter: " + err);
+            }
+        } else {
+            if (params[i].length > 0) {
+                try {
+                    msg += "    " + Y(strip(decodeURIComponent(params[i]))) + "\n";
+                } catch(err) {
+                    msg += "    " + Y(strip(params[i])) + "\n";
+                    log_debug("could not decode URI parameter: " + err);
+                }
+            }
+        }
+    }
+
+    console.log(msg);
 }
 
 function dumpJSON(req) {
-    log( "  > " + BOLD(G("JSON")) );
+    msg = "  " + BOLD("JSON") + "\n\n";
 
     var body = req.ReadBody();
 
-    // TODO: pretty print json
-    log( "   " + Y(body) );
-}
+    if (req.Body.length > 0) {
+        try {
+            json = JSON.parse(body);
+            json_msg = JSON.stringify(json, null, 4);
 
-function pad(num, size, fill) {
-    var s = "" + num;
+            msg_lines = json_msg.split("\n");
 
-    while (s.length < size) {
-        s = fill + s;
+            for (var i = 0; i < msg_lines.length; i++) {
+                msg += "    " + msg_lines[i].replace(/^(\s*)\{$/,                  "$1" + B("{"))
+                                            .replace(/^(\s*)\[$/,                  "$1" + B("["))
+                                            .replace(/^(\s*)(".*?"): \{$/,         "$1" + B("$2") + ": " + B("{"))
+                                            .replace(/^(\s*)(".*?"): \[$/,         "$1" + B("$2") + ": " + B("["))
+                                            .replace(/^(\s*)(".*?"): (.*?)(,$|$)/, "$1" + B("$2") + ": " + Y("$3") + "$4")
+                                            .replace(/^(\s*)(".*?")(,$|$)/,        "$1" + Y("$2") + "$3")
+                                            .replace(/^(\s*)(\d*?)(,$|$)/,         "$1" + Y("$2") + "$3")
+                                            .replace(/^(\s*)\](,$|$)/,             "$1" + B("]") + "$2")
+                                            .replace(/^(\s*)\}(,$|$)/,             "$1" + B("}") + "$2") + "\n";
+            }
+        } catch(ignore) {
+            msg += "    " + Y(body) + "\n";
+        }
+
+        console.log(msg);
     }
-
-    return s;
 }
 
-function toHex(n) {
-    var hex = "0123456789abcdef";
-    var h = hex[(0xF0 & n) >> 4] + hex[0x0F & n];
-    return pad(h, 2, "0");
-}
-
-function isPrint(c) {
-    if (!c) { return false; }
-    var code = c.charCodeAt(0);
-    return (code > 31) && (code < 127);
-}
-
-function dumpHex(raw, linePad) {
+function dumpHex(raw) {
     var DataSize = raw.length;
     var Bytes = 16;
+
+    msg = "";
 
     for (var address = 0; address < DataSize; address++) {
         var saddr = pad(address, 8, "0");
@@ -104,36 +159,64 @@ function dumpHex(raw, linePad) {
 
         address = end;
 
-        log( linePad + G(saddr) + "  " + shex + " " + sprint );
+        msg += "    " + G(saddr) + "  " + shex + " " + sprint + "\n";
     }
+
+    console.log(msg);
 }
 
 function dumpRaw(req) {
     var body = req.ReadBody();
 
-    log( "  > " + BOLD(G("Body")) + " " + DIM("(" + body.length + " bytes)") + "\n" );
+    if (body.length > 0) {
+        console.log("  " + BOLD("Body") + " " + DIM("(" + body.length + " bytes)") + "\n");
 
-    dumpHex(body, "    ");
+        dumpHex(body);
+    }
+}
+
+function pad(num, size, fill) {
+    var s = "" + num;
+
+    while (s.length < size) {
+        s = fill + s;
+    }
+
+    return s;
+}
+
+function strip(s) {
+    return s.replace(/^\s*/, "").replace(/\s*$/, "");
+}
+
+function toHex(n) {
+    var hex = "0123456789abcdef";
+    var h = hex[(0xF0 & n) >> 4] + hex[0x0F & n];
+    return pad(h, 2, "0");
+}
+
+function isPrint(c) {
+    if (!c) { return false; }
+    var code = c.charCodeAt(0);
+    return (code > 31) && (code < 127);
 }
 
 function onRequest(req, res) {
-    log( BOLD(req.Client) + " > " + B(req.Method) + " " + req.Hostname + req.Path + (req.Query ? "?" + req.Query : "") );
+    log("[" + G("http-req-dump") + "] " + BLACK_RED("http") + " " + req.Client + " " + BLACK_BLUE(req.Method) + " " + GREY("http://") + Y(req.Hostname) + req.Path + (req.Query != "" ? GREY("?" + req.Query) : ""));
 
     dumpHeaders(req);
 
-    if (req.ContentType) {
-        log();
-
-        if (req.ContentType.indexOf("text/plain") != -1) {
-            dumpPlain(req);
-        } else if (req.ContentType.indexOf("application/x-www-form-urlencoded") != -1) {
-            dumpForm(req);
-        } else if (req.ContentType.indexOf("application/json") != -1) {
-            dumpJSON(req);
-        } else {
-            dumpRaw(req);
-        }
+    if (req.Query.length > 0) {
+        dumpQuery(req);
     }
 
-    log();
+    if (req.ContentType.indexOf("text/plain") != -1) {
+        dumpPlain(req);
+    } else if (req.ContentType.indexOf("application/x-www-form-urlencoded") != -1) {
+        dumpForm(req);
+    } else if (req.ContentType.indexOf("application/json") != -1) {
+        dumpJSON(req);
+    } else {
+        dumpRaw(req);
+    }
 }


### PR DESCRIPTION
### Changes:

 - pretty print JSON
 - pretty print request queries
 - empty bodies are skipped
 - colors are similar to net.sniff.leak color scheme
 - added `http://` to logs so entire URL gets highlighted
 - log message are generated before they are printed to reduce mixed logs

<hr>

I made a few changes to the http-req-dump module:

<b>JSON is formatted</b>

![bcap-json](https://user-images.githubusercontent.com/29265684/46269266-5effa500-c583-11e8-9213-5e874a285589.png)

<b>Request queries are formatted</b>

![bcap-query](https://user-images.githubusercontent.com/29265684/46269275-70e14800-c583-11e8-929d-bc7267389ba9.png)

 - **empty bodies/forms/json and queries are no longer printed**
 - **http:// is added to URLs so they are easier to select**
 - **formatting and colors are similar to net.sniff.leak**
 - **log messages are prepared before they are printed to reduce the amount of mixed logs**

![bcap-url](https://user-images.githubusercontent.com/29265684/46269298-8f474380-c583-11e8-8b10-118bcaaeeffb.png)

This is an awesome HTTP sniffer and I'm finding all sorts of interesting things :D

![bcap-funny-js](https://user-images.githubusercontent.com/29265684/46269345-e816dc00-c583-11e8-99eb-fe403ce21852.png)

### To do:

 - pretty print XML
 - add request dump filters