### PR TITLE
print api credentials with ui caplet

### DIFF
--- a/http-ui.cap
+++ b/http-ui.cap
@@ -10,6 +10,10 @@ set http.server.path /usr/local/share/bettercap/ui
 set api.rest.username user
 set api.rest.password pass
 
+# print api credentials
+get api.rest.username
+get api.rest.password
+
 # go!
 api.rest on
 http.server on

--- a/https-ui.cap
+++ b/https-ui.cap
@@ -16,6 +16,10 @@ set https.server.path /usr/local/share/bettercap/ui
 set api.rest.username user
 set api.rest.password pass
 
+# print api credentials
+get api.rest.username
+get api.rest.password
+
 # go!
 api.rest on
 https.server on


### PR DESCRIPTION
This will print the `api.rest.username` and `api.rest.password` values when http-ui.cap and https-ui.cap are loaded.

closes https://github.com/bettercap/ui/issues/10