### PR TITLE
change ui directory for http-ui https-ui

### DIFF
--- a/http-ui.cap
+++ b/http-ui.cap
@@ -4,7 +4,7 @@ set api.rest.port 8081
 set http.server.address 127.0.0.1
 set http.server.port 80
 # default installation path of the ui
-set http.server.path /usr/local/share/bettercap/ui
+set http.server.path /usr/share/bettercap/ui
 
 # !!! CHANGE THESE !!!
 set api.rest.username user

--- a/https-ui.cap
+++ b/https-ui.cap
@@ -10,7 +10,7 @@ set https.server.key ~/.bettercap-https.key.pem
 set api.rest.certificate ~/.bettercap-https.cert.pem
 set api.rest.key ~/.bettercap-https.key.pem 
 # default installation path of the ui
-set https.server.path /usr/local/share/bettercap/ui
+set https.server.path /usr/share/bettercap/ui
 
 # !!! CHANGE THESE !!!
 set api.rest.username user


### PR DESCRIPTION
both files where pointing to /usr/local/share/bettercap/ui but bettercap is installing the ui to /usr/share/bettercap/ui/

This was causing a 404 message when attempting to follow the instructions on the documentation or when trying to use the docker image.