### PR TITLE
update tcp-req-dump to work with binary data

### DIFF
--- a/tcp-req-dump/tcp-req-dump.cap
+++ b/tcp-req-dump/tcp-req-dump.cap
@@ -8,7 +8,7 @@
 # we'll use this proxy script to dump requests
 set tcp.proxy.script tcp-req-dump.js
 set tcp.port 80
-# example.com
+# example.com, victim server
 set tcp.address 93.184.216.34
 set tcp.proxy.port 8080
 

--- a/tcp-req-dump/tcp-req-dump.js
+++ b/tcp-req-dump/tcp-req-dump.js
@@ -2,12 +2,21 @@ function onLoad() {
     log("TCP module loaded")
 }
 
-function onData(from, to, data) {
-    if( data.indexOf("Accept-Encoding: gzip, deflate") != -1 ) {
-        log("Disabling gzip response");
-        data = data.replace("Accept-Encoding: gzip, deflate", "Accept-Encoding: text/plain");
-        return data;
-    }
+function charToInt(value) { 
+    return value.charCodeAt()
+}
 
-    return data.replace(/Example/g, "POPOPOP");
+
+function onData(from, to, data) {
+    //log(data) // 104 101 108 108 111
+    st_data = String.fromCharCode.apply(null, data)
+    log("TCP req dump String data: " + st_data) // "hello"
+  
+    if( st_data.indexOf("Accept-Encoding: gzip, deflate") != -1 ) {
+        log("Disabling gzip response");
+        st_data = st_data.replace("Accept-Encoding: gzip, deflate", "Accept-Encoding: text/plain");
+        res_int_arr = st_data.split("").map(charToInt)
+        return res_int_arr
+    }
+    return data
 }


### PR DESCRIPTION
previous rewrite transformed data parameter from string to binary array, making the JS caplet code not work.