### PR TITLE
fix(js): prevent crashes by validating res.Headers before splitting

### DIFF
--- a/gitspoof/gitspoof.js
+++ b/gitspoof/gitspoof.js
@@ -18,10 +18,14 @@ function onResponse(req, res) {
     }
     if (req.Query == 'service=git-upload-pack' && req.Hostname != gitspoof_repo) {
         res.Status = 301;
-        headers = res.Headers.split("\r\n");
-        for (var i = 0; i < headers.length; i++) {
-            header_name = headers[i].replace(/:.*/, "");
-            res.RemoveHeader(header_name);
+        if (res.Headers) {
+            var headers = res.Headers.split("\r\n");
+            for (var i = 0; i < headers.length; i++) {
+                if (headers[i]) {
+                    var header_name = headers[i].replace(/:.*/, "");
+                    res.RemoveHeader(header_name);
+                }
+            }
         }
         res.SetHeader("Location", "http://" + gitspoof_repo + "/info/refs?service=git-upload-pack");
         res.Body = "";

--- a/web-override/web-override.js
+++ b/web-override/web-override.js
@@ -1,10 +1,14 @@
 // Called before every request is executed, just override the response with 
 // our own html web page.
 function onRequest(req, res) {
-    headers = res.Headers.split("\r\n");
-    for (var i = 0; i < headers.length; i++) {
-        header_name = headers[i].replace(/:.*/, "");
-        res.RemoveHeader(header_name);
+    if (res.Headers) {
+        var headers = res.Headers.split("\r\n");
+        for (var i = 0; i < headers.length; i++) {
+            if (headers[i]) {
+                var header_name = headers[i].replace(/:.*/, "");
+                res.RemoveHeader(header_name);
+            }
+        }
     }
     res.SetHeader("Connection", "close");
     res.Status      = 200;


### PR DESCRIPTION
Checks if res.Headers is defined and not null before performing split operations in gitspoof and web-override proxy scripts. This prevents TypeError crashes when res.Headers is undefined, particularly during the onRequest phase.